### PR TITLE
fix: fail-closed when OPENAI_API_KEY missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ cd ROS-LLM/llm_install
 bash config_openai_api_key.sh
 ```
 
+> **Note:** The ChatGPT ROS node fails closed at import if `OPENAI_API_KEY` is missing or empty.
+
 **4. Configure AWS Settings (Optional):**
 
 For cloud natural interaction capabilities, configure the AWS settings. If you prefer to use local ASR, this step can be skipped.

--- a/llm_config/llm_config/user_config.py
+++ b/llm_config/llm_config/user_config.py
@@ -46,7 +46,11 @@ class UserConfig:
     def __init__(self):
         # OpenAI API related
         # [required]: OpenAI API key
-        self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        raw_openai_key = os.getenv("OPENAI_API_KEY")
+        # Treat missing or whitespace-only keys as unset (fail closed downstream).
+        self.openai_api_key = (
+            raw_openai_key.strip() if isinstance(raw_openai_key, str) and raw_openai_key.strip() else None
+        )
         # [required]: Name of the OpenAI language model to be used
         self.openai_model = "gpt-3.5-turbo-0613"
         # self.openai_model="gpt-4-0613"

--- a/llm_config/test/test_user_config_api_key.py
+++ b/llm_config/test/test_user_config_api_key.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline tests for UserConfig OPENAI_API_KEY normalization."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# package lives at llm_config/llm_config
+_ROOT = Path(__file__).resolve().parents[1]
+_PKG_PARENT = _ROOT  # contains package dir llm_config/
+if str(_PKG_PARENT) not in sys.path:
+    sys.path.insert(0, str(_PKG_PARENT))
+
+
+class TestUserConfigApiKey(unittest.TestCase):
+    def test_missing_env(self):
+        from llm_config.user_config import UserConfig
+
+        def fake_getenv(k, default=None):
+            if k == "OPENAI_API_KEY":
+                return None
+            return os.environ.get(k, default)
+
+        with mock.patch.object(os, "getenv", side_effect=fake_getenv):
+            cfg = UserConfig()
+        self.assertIsNone(cfg.openai_api_key)
+
+    def test_whitespace_only(self):
+        from llm_config.user_config import UserConfig
+
+        def fake_getenv(k, default=None):
+            if k == "OPENAI_API_KEY":
+                return "   "
+            return os.environ.get(k, default)
+
+        with mock.patch.object(os, "getenv", side_effect=fake_getenv):
+            cfg = UserConfig()
+        self.assertIsNone(cfg.openai_api_key)
+
+    def test_valid_key(self):
+        from llm_config.user_config import UserConfig
+
+        def fake_getenv(k, default=None):
+            if k == "OPENAI_API_KEY":
+                return "sk-test"
+            return os.environ.get(k, default)
+
+        with mock.patch.object(os, "getenv", side_effect=fake_getenv):
+            cfg = UserConfig()
+        self.assertEqual(cfg.openai_api_key, "sk-test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -50,6 +50,11 @@ from llm_config.user_config import UserConfig
 
 # Global Initialization
 config = UserConfig()
+if not config.openai_api_key:
+    raise RuntimeError(
+        "OPENAI_API_KEY is not set or is empty. "
+        "Export OPENAI_API_KEY or run llm_install/config_openai_api_key.sh before starting chatgpt."
+    )
 openai.api_key = config.openai_api_key
 # openai.organization = config.openai_organization
 


### PR DESCRIPTION
## Summary
- Treat missing/whitespace-only `OPENAI_API_KEY` as unset in `UserConfig`.
- Raise a clear `RuntimeError` at ChatGPT node import when the key is absent (fail-closed).
- Offline unit tests for key normalization + short README note.

## Test plan
- [x] `cd llm_config && PYTHONPATH=. python3 -m unittest discover -s test -p 'test_user_config*.py' -v`
- [ ] Maintainer: import path with key set still works as before.

## Notes
Aerial / drone-agent OSS campaign micro-PR (docs+security hygiene). Spec: `specs/ros-llm/2026-07-14-1.md`.