### PR TITLE
fix(robot): reject non-finite cmd_vel for turtlesim demo

### DIFF
--- a/llm_robot/llm_robot/cmd_vel_sanitize.py
+++ b/llm_robot/llm_robot/cmd_vel_sanitize.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2023 Herman Ye @Auromix (package); sanitize helper 2026 contrib
+# Licensed under the Apache License, Version 2.0
+"""Sanitize LLM-supplied cmd_vel scalars for the turtlesim demo."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+DEFAULT_MAX_ABS = 2.0
+
+
+def sanitize_cmd_vel_float(
+    value: Any,
+    name: str,
+    *,
+    max_abs: float = DEFAULT_MAX_ABS,
+) -> float:
+    """Coerce to float; reject non-finite; clamp to [-max_abs, max_abs]."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"cmd_vel field {name!r} must be a number, got {value!r}") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"cmd_vel field {name!r} must be finite, got {number!r}")
+    if max_abs < 0:
+        raise ValueError("max_abs must be non-negative")
+    if number > max_abs:
+        return float(max_abs)
+    if number < -max_abs:
+        return float(-max_abs)
+    return number

--- a/llm_robot/llm_robot/readme.md
+++ b/llm_robot/llm_robot/readme.md
@@ -24,3 +24,6 @@ by creating a publisher for cmd_vel messages and a client for the reset service.
 It also includes a ChatGPT function call server
 that can call various functions to control the TurtleSim
 and return the result of the function call as a string.
+
+## Safety note
+Turtlesim `publish_cmd_vel` rejects non-finite values and clamps magnitudes to a modest demo bound (`cmd_vel_sanitize.py`).

--- a/llm_robot/llm_robot/turtle_robot.py
+++ b/llm_robot/llm_robot/turtle_robot.py
@@ -40,6 +40,7 @@ from std_srvs.srv import Empty
 # LLM related
 import json
 from llm_config.user_config import UserConfig
+from llm_robot.cmd_vel_sanitize import sanitize_cmd_vel_float
 
 # Global Initialization
 config = UserConfig()
@@ -80,20 +81,20 @@ class TurtleRobot(Node):
         """
         Publishes cmd_vel message to control the movement of turtlesim
         """
-        linear_x = kwargs.get("linear_x", 0.0)
-        linear_y = kwargs.get("linear_y", 0.0)
-        linear_z = kwargs.get("linear_z", 0.0)
-        angular_x = kwargs.get("angular_x", 0.0)
-        angular_y = kwargs.get("angular_y", 0.0)
-        angular_z = kwargs.get("angular_z", 0.0)
+        linear_x = sanitize_cmd_vel_float(kwargs.get("linear_x", 0.0), "linear_x")
+        linear_y = sanitize_cmd_vel_float(kwargs.get("linear_y", 0.0), "linear_y")
+        linear_z = sanitize_cmd_vel_float(kwargs.get("linear_z", 0.0), "linear_z")
+        angular_x = sanitize_cmd_vel_float(kwargs.get("angular_x", 0.0), "angular_x")
+        angular_y = sanitize_cmd_vel_float(kwargs.get("angular_y", 0.0), "angular_y")
+        angular_z = sanitize_cmd_vel_float(kwargs.get("angular_z", 0.0), "angular_z")
 
         twist_msg = Twist()
-        twist_msg.linear.x = float(linear_x)
-        twist_msg.linear.y = float(linear_y)
-        twist_msg.linear.z = float(linear_z)
-        twist_msg.angular.x = float(angular_x)
-        twist_msg.angular.y = float(angular_y)
-        twist_msg.angular.z = float(angular_z)
+        twist_msg.linear.x = linear_x
+        twist_msg.linear.y = linear_y
+        twist_msg.linear.z = linear_z
+        twist_msg.angular.x = angular_x
+        twist_msg.angular.y = angular_y
+        twist_msg.angular.z = angular_z
 
         self.publisher_.publish(twist_msg)
         self.get_logger().info(f"Publishing cmd_vel message successfully: {twist_msg}")

--- a/llm_robot/test/test_cmd_vel_sanitize.py
+++ b/llm_robot/test/test_cmd_vel_sanitize.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline tests for cmd_vel sanitization (no rclpy required)."""
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from llm_robot.cmd_vel_sanitize import sanitize_cmd_vel_float
+
+
+class TestCmdVelSanitize(unittest.TestCase):
+    def test_normal(self):
+        self.assertEqual(sanitize_cmd_vel_float(1.0, "linear_x"), 1.0)
+        self.assertEqual(sanitize_cmd_vel_float("-0.5", "angular_z"), -0.5)
+
+    def test_nan_inf(self):
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float(float("nan"), "linear_x")
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float(float("inf"), "angular_z")
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float(-math.inf, "linear_y")
+
+    def test_clamp(self):
+        self.assertEqual(sanitize_cmd_vel_float(10.0, "linear_x", max_abs=2.0), 2.0)
+        self.assertEqual(sanitize_cmd_vel_float(-9.0, "angular_z", max_abs=2.0), -2.0)
+
+    def test_bad_type(self):
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float("nope", "linear_x")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `cmd_vel_sanitize.sanitize_cmd_vel_float` (finite check + soft clamp).
- Wire into turtlesim `publish_cmd_vel` so non-finite LLM args fail closed.
- Offline unit tests (no rclpy graph required).

## Test plan
- [x] `cd llm_robot && PYTHONPATH=. python3 -m unittest discover -s test -p 'test_cmd_vel*.py' -v`

## Notes
Aerial campaign micro-PR. Does not change multi_robot/arx5. Spec: `specs/ros-llm/2026-07-14-2.md`.