### PR TITLE
fix(robot): reject non-finite cmd_vel for multi_robot

### DIFF
--- a/llm_robot/llm_robot/cmd_vel_sanitize.py
+++ b/llm_robot/llm_robot/cmd_vel_sanitize.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2023 Herman Ye @Auromix (package); sanitize helper 2026 contrib
+# Licensed under the Apache License, Version 2.0
+"""Sanitize LLM-supplied cmd_vel scalars for ROS-LLM demos."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+DEFAULT_MAX_ABS = 2.0
+DEFAULT_MAX_DURATION = 30.0
+
+
+def sanitize_cmd_vel_float(
+    value: Any,
+    name: str,
+    *,
+    max_abs: float = DEFAULT_MAX_ABS,
+) -> float:
+    """Coerce to float; reject non-finite; clamp to [-max_abs, max_abs]."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"cmd_vel field {name!r} must be a number, got {value!r}"
+        ) from exc
+    if not math.isfinite(number):
+        raise ValueError(f"cmd_vel field {name!r} must be finite, got {number!r}")
+    if max_abs < 0:
+        raise ValueError("max_abs must be non-negative")
+    if number > max_abs:
+        return float(max_abs)
+    if number < -max_abs:
+        return float(-max_abs)
+    return number
+
+
+def sanitize_duration(
+    value: Any,
+    *,
+    max_sec: float = DEFAULT_MAX_DURATION,
+    default: float = 0.0,
+) -> float:
+    """Coerce duration seconds; non-finite/negative → default; clamp to max_sec."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if not math.isfinite(number) or number < 0:
+        return float(default)
+    if max_sec < 0:
+        raise ValueError("max_sec must be non-negative")
+    if number > max_sec:
+        return float(max_sec)
+    return number

--- a/llm_robot/llm_robot/multi_robot.py
+++ b/llm_robot/llm_robot/multi_robot.py
@@ -33,6 +33,10 @@ from llm_interfaces.srv import ChatGPT
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_robot.cmd_vel_sanitize import (
+    sanitize_cmd_vel_float,
+    sanitize_duration,
+)
 
 config = UserConfig()
 
@@ -113,13 +117,17 @@ class MultiRobot(Node):
         """
         # Get parameters
         robot_name = kwargs.get("robot_name", "")
-        duration = kwargs.get("duration", 0)
-        linear_x = kwargs.get("linear_x", 0.0)
-        linear_y = kwargs.get("linear_y", 0.0)
-        linear_z = kwargs.get("linear_z", 0.0)
-        angular_x = kwargs.get("angular_x", 0.0)
-        angular_y = kwargs.get("angular_y", 0.0)
-        angular_z = kwargs.get("angular_z", 0.0)
+        duration = sanitize_duration(kwargs.get("duration", 0))
+        try:
+            linear_x = sanitize_cmd_vel_float(kwargs.get("linear_x", 0.0), "linear_x")
+            linear_y = sanitize_cmd_vel_float(kwargs.get("linear_y", 0.0), "linear_y")
+            linear_z = sanitize_cmd_vel_float(kwargs.get("linear_z", 0.0), "linear_z")
+            angular_x = sanitize_cmd_vel_float(kwargs.get("angular_x", 0.0), "angular_x")
+            angular_y = sanitize_cmd_vel_float(kwargs.get("angular_y", 0.0), "angular_y")
+            angular_z = sanitize_cmd_vel_float(kwargs.get("angular_z", 0.0), "angular_z")
+        except ValueError as err:
+            self.get_logger().error(f"Rejected unsafe cmd_vel: {err}")
+            raise
         self.get_logger().debug(f"Received cmd_vel message: {kwargs}")
         # Create message
         twist_msg = Twist()

--- a/llm_robot/llm_robot/readme.md
+++ b/llm_robot/llm_robot/readme.md
@@ -24,3 +24,7 @@ by creating a publisher for cmd_vel messages and a client for the reset service.
 It also includes a ChatGPT function call server
 that can call various functions to control the TurtleSim
 and return the result of the function call as a string.
+
+## multi_robot cmd_vel safety
+LLM-supplied vel components are rejected when non-finite; values are clamped to |v|<=2. Duration is clamped to [0,30]s.
+

--- a/llm_robot/test/test_cmd_vel_sanitize.py
+++ b/llm_robot/test/test_cmd_vel_sanitize.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline tests for cmd_vel sanitization (no rclpy required)."""
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from llm_robot.cmd_vel_sanitize import sanitize_cmd_vel_float, sanitize_duration
+
+
+class TestCmdVelSanitize(unittest.TestCase):
+    def test_normal(self):
+        self.assertEqual(sanitize_cmd_vel_float(1.0, "linear_x"), 1.0)
+        self.assertEqual(sanitize_cmd_vel_float("-0.5", "angular_z"), -0.5)
+
+    def test_nan_inf(self):
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float(float("nan"), "linear_x")
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float(float("inf"), "angular_z")
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float(-math.inf, "linear_y")
+
+    def test_clamp(self):
+        self.assertEqual(sanitize_cmd_vel_float(10.0, "linear_x", max_abs=2.0), 2.0)
+        self.assertEqual(sanitize_cmd_vel_float(-9.0, "angular_z", max_abs=2.0), -2.0)
+
+    def test_bad_type(self):
+        with self.assertRaises(ValueError):
+            sanitize_cmd_vel_float("nope", "linear_x")
+
+    def test_duration(self):
+        self.assertEqual(sanitize_duration(1.5), 1.5)
+        self.assertEqual(sanitize_duration(-1), 0.0)
+        self.assertEqual(sanitize_duration(float("nan")), 0.0)
+        self.assertEqual(sanitize_duration(float("inf")), 0.0)
+        self.assertEqual(sanitize_duration(999, max_sec=30.0), 30.0)
+        self.assertEqual(sanitize_duration("unicode"), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `cmd_vel_sanitize.sanitize_cmd_vel_float` / `sanitize_duration` for LLM-supplied multi-robot cmd_vel.
- `MultiRobot.publish_cmd_vel` rejects non-finite values and clamps |v|≤2; duration capped to [0, 30]s so junk args cannot spin forever.
- Offline unit tests (no rclpy).

## Test plan
- [x] `PYTHONPATH=llm_robot python3 -m unittest discover -s llm_robot/test -p 'test_cmd_vel*.py' -v`

Aerial campaign micro-PR (docs/safety). Related open turtlesim path: #18.