### PR TITLE
fix(robot): sanitize arx5 target_pose and drop shell pub

### DIFF
--- a/llm_robot/llm_robot/arx5_arm_robot.py
+++ b/llm_robot/llm_robot/arx5_arm_robot.py
@@ -39,8 +39,8 @@ from std_srvs.srv import Empty
 
 # LLM related
 import json
-import os
 from llm_config.user_config import UserConfig
+from llm_robot.target_pose_sanitize import sanitize_target_pose
 
 # Global Initialization
 config = UserConfig()
@@ -78,22 +78,16 @@ class ArmRobot(Node):
 
     def publish_target_pose(self, **kwargs):
         """
-        Publishes target_pose message to control the movement of arx5_arm
+        Publishes target_pose message to control the movement of arx5_arm.
+
+        LLM args are sanitized (finite + soft workspace clamps). Uses the
+        native publisher instead of shelling out to `ros2 topic pub`.
         """
-
-        x_value = kwargs.get("x", 0.2)
-        y_value = kwargs.get("y", 0.2)
-        z_value = kwargs.get("z", 0.2)
-
-        roll_value = kwargs.get("roll", 0.2)
-        pitch_value = kwargs.get("pitch", 0.2)
-        yaw_value = kwargs.get("yaw", 0.2)
-
-        pose = [x_value, y_value, z_value, roll_value, pitch_value, yaw_value]
-        pose_str = ', '.join(map(str, pose))
-
-        command=f"ros2 topic pub /target_pose std_msgs/msg/Float64MultiArray '{{data: [{pose_str}]}}' -1"
-        os.system(command)
+        pose = sanitize_target_pose(kwargs)
+        msg = Float64MultiArray()
+        msg.data = pose
+        self.target_pose_publisher.publish(msg)
+        pose_str = ", ".join(map(str, pose))
         self.get_logger().info(f"Published target message successfully: {pose}")
         return pose_str
 

--- a/llm_robot/llm_robot/readme.md
+++ b/llm_robot/llm_robot/readme.md
@@ -24,3 +24,7 @@ by creating a publisher for cmd_vel messages and a client for the reset service.
 It also includes a ChatGPT function call server
 that can call various functions to control the TurtleSim
 and return the result of the function call as a string.
+
+## arx5 target_pose safety
+`publish_target_pose` sanitizes xyz/rpy (finite + soft clamps) and publishes via Float64MultiArray (no shell).
+

--- a/llm_robot/llm_robot/target_pose_sanitize.py
+++ b/llm_robot/llm_robot/target_pose_sanitize.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2023 Herman Ye @Auromix (package); sanitize helper 2026 contrib
+# Licensed under the Apache License, Version 2.0
+"""Sanitize LLM-supplied target pose for arx5 arm demo (workspace soft limits)."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Mapping
+
+
+# Soft demo workspace clamps (meters / radians) — not a substitute for real FK limits.
+DEFAULT_MAX_ABS_XYZ = 2.0
+DEFAULT_MAX_ABS_RPY = math.pi
+
+
+def sanitize_pose_component(
+    value: Any,
+    name: str,
+    *,
+    default: float,
+    max_abs: float,
+) -> float:
+    """Coerce to finite float; clamp to [-max_abs, max_abs]; bad type → default then clamp."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        number = float(default)
+    if not math.isfinite(number):
+        number = float(default)
+    if max_abs < 0:
+        raise ValueError("max_abs must be non-negative")
+    if number > max_abs:
+        return float(max_abs)
+    if number < -max_abs:
+        return float(-max_abs)
+    return number
+
+
+def sanitize_target_pose(
+    kwargs: Mapping[str, Any],
+    *,
+    max_abs_xyz: float = DEFAULT_MAX_ABS_XYZ,
+    max_abs_rpy: float = DEFAULT_MAX_ABS_RPY,
+) -> List[float]:
+    """Return [x, y, z, roll, pitch, yaw] sanitized from kwargs."""
+    defaults = {
+        "x": 0.2,
+        "y": 0.2,
+        "z": 0.2,
+        "roll": 0.2,
+        "pitch": 0.2,
+        "yaw": 0.2,
+    }
+    out: List[float] = []
+    for key in ("x", "y", "z"):
+        out.append(
+            sanitize_pose_component(
+                kwargs.get(key, defaults[key]),
+                key,
+                default=defaults[key],
+                max_abs=max_abs_xyz,
+            )
+        )
+    for key in ("roll", "pitch", "yaw"):
+        out.append(
+            sanitize_pose_component(
+                kwargs.get(key, defaults[key]),
+                key,
+                default=defaults[key],
+                max_abs=max_abs_rpy,
+            )
+        )
+    return out

--- a/llm_robot/test/test_target_pose_sanitize.py
+++ b/llm_robot/test/test_target_pose_sanitize.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline tests for arx5 target pose sanitization (no rclpy)."""
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from llm_robot.target_pose_sanitize import sanitize_pose_component, sanitize_target_pose
+
+
+class TestTargetPoseSanitize(unittest.TestCase):
+    def test_defaults(self):
+        pose = sanitize_target_pose({})
+        self.assertEqual(len(pose), 6)
+        self.assertTrue(all(math.isfinite(v) for v in pose))
+
+    def test_nan_falls_to_default(self):
+        pose = sanitize_target_pose({"x": float("nan"), "y": 0.1})
+        self.assertEqual(pose[0], 0.2)  # default then finite
+        self.assertEqual(pose[1], 0.1)
+
+    def test_clamp_xyz_rpy(self):
+        pose = sanitize_target_pose(
+            {"x": 50.0, "roll": 10.0}, max_abs_xyz=2.0, max_abs_rpy=math.pi
+        )
+        self.assertEqual(pose[0], 2.0)
+        self.assertLessEqual(pose[3], math.pi + 1e-9)
+
+    def test_component_bad_type(self):
+        self.assertEqual(
+            sanitize_pose_component("x", "x", default=0.2, max_abs=2.0), 0.2
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `target_pose_sanitize` for finite soft workspace clamps on xyz/rpy.
- `ArmRobot.publish_target_pose` uses native `Float64MultiArray` publisher instead of `os.system('ros2 topic pub …')` (shell-injection risk from LLM kwargs).
- Offline unit tests (no rclpy).

## Test plan
- [x] `PYTHONPATH=llm_robot python3 -m unittest discover -s llm_robot/test -p 'test_target_pose*.py' -v`

Aerial campaign micro-PR (security/safety). Soft clamps are demo-only; real arms need proper IK/joint limits.