### PR TITLE
fix(robot): sanitize multi_robot call_service name/type args

### DIFF
--- a/llm_robot/llm_robot/multi_robot.py
+++ b/llm_robot/llm_robot/multi_robot.py
@@ -30,6 +30,7 @@ from std_msgs.msg import String
 from geometry_msgs.msg import Pose
 from geometry_msgs.msg import Twist
 from llm_interfaces.srv import ChatGPT
+from llm_robot.ros_arg_sanitize import sanitize_service_call_args
 
 # Global Initialization
 from llm_config.user_config import UserConfig
@@ -98,7 +99,13 @@ class MultiRobot(Node):
         # TODO: Add support for non-empty input service
         service_name = kwargs.get("service_name", "")
         service_type = kwargs.get("service_type", "")
-        command = ["ros2", "service", "call", service_name, service_type]
+        ok, name_or_err, type_or_empty = sanitize_service_call_args(
+            service_name, service_type
+        )
+        if not ok:
+            self.get_logger().info(f"Rejected call_service: {name_or_err}")
+            return name_or_err
+        command = ["ros2", "service", "call", name_or_err, type_or_empty]
 
         try:
             command_result = subprocess.check_output(command, stderr=subprocess.STDOUT)

--- a/llm_robot/llm_robot/ros_arg_sanitize.py
+++ b/llm_robot/llm_robot/ros_arg_sanitize.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok9 (Aerial OSS campaign)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed validators for ros2 service call argv pieces from LLM function args.
+
+from __future__ import annotations
+
+import re
+from typing import Tuple, Union
+
+# Optional leading slash; one or more [A-Za-z0-9_]+ segments joined by /
+_ROS_NAME = re.compile(r"^/?[A-Za-z][A-Za-z0-9_]*(?:/[A-Za-z][A-Za-z0-9_]*)*$")
+# package/Type or package/srv/Type style (1–3 slash segments after package)
+_ROS_TYPE = re.compile(
+    r"^[A-Za-z][A-Za-z0-9_]*(?:/[A-Za-z][A-Za-z0-9_]*){1,3}$"
+)
+
+
+def is_valid_ros_name(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    if any(c.isspace() or c in ";|&$`\\\"'<>" for c in value):
+        return False
+    return bool(_ROS_NAME.match(value))
+
+
+def is_valid_ros_type(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    if any(c.isspace() or c in ";|&$`\\\"'<>" for c in value):
+        return False
+    return bool(_ROS_TYPE.match(value))
+
+
+def sanitize_service_call_args(
+    service_name: object, service_type: object
+) -> Tuple[bool, str, str]:
+    """
+    Returns (ok, name_or_err, type_or_err).
+    When ok is False, second element is the error message.
+    """
+    if not is_valid_ros_name(service_name):
+        return False, "invalid service_name", ""
+    if not is_valid_ros_type(service_type):
+        return False, "invalid service_type", ""
+    return True, str(service_name), str(service_type)

--- a/llm_robot/test/test_ros_arg_sanitize.py
+++ b/llm_robot/test/test_ros_arg_sanitize.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2026 Bartok9 (Aerial OSS campaign)
+# Licensed under the Apache License, Version 2.0
+
+import unittest
+
+from llm_robot.ros_arg_sanitize import (
+    is_valid_ros_name,
+    is_valid_ros_type,
+    sanitize_service_call_args,
+)
+
+
+class TestRosArgSanitize(unittest.TestCase):
+    def test_valid_names(self):
+        self.assertTrue(is_valid_ros_name("/reset"))
+        self.assertTrue(is_valid_ros_name("turtle1/reset"))
+        self.assertTrue(is_valid_ros_name("/foo/bar_baz"))
+
+    def test_invalid_names(self):
+        self.assertFalse(is_valid_ros_name(""))
+        self.assertFalse(is_valid_ros_name("a;rm -rf /"))
+        self.assertFalse(is_valid_ros_name("../etc"))
+        self.assertFalse(is_valid_ros_name("has space"))
+        self.assertFalse(is_valid_ros_name(None))
+
+    def test_valid_types(self):
+        self.assertTrue(is_valid_ros_type("std_srvs/Empty"))
+        self.assertTrue(is_valid_ros_type("std_srvs/srv/Empty"))
+
+    def test_invalid_types(self):
+        self.assertFalse(is_valid_ros_type(""))
+        self.assertFalse(is_valid_ros_type("Empty"))  # needs package/
+        self.assertFalse(is_valid_ros_type("std_srvs/Empty;id"))
+
+    def test_sanitize_ok(self):
+        ok, n, t = sanitize_service_call_args("/reset", "std_srvs/srv/Empty")
+        self.assertTrue(ok)
+        self.assertEqual(n, "/reset")
+        self.assertEqual(t, "std_srvs/srv/Empty")
+
+    def test_sanitize_bad(self):
+        ok, err, _ = sanitize_service_call_args("bad name", "std_srvs/Empty")
+        self.assertFalse(ok)
+        self.assertIn("invalid", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fail-closed validation of LLM-provided service_name / service_type before ros2 service call subprocess argv in MultiRobot.call_service.

## Motivation
Function-call args can include spaces, metacharacters, or non-ROS tokens. The CLI is already argv-based (no shell), but invalid graph names/types should never reach the tool binary.

## Changes
- llm_robot/ros_arg_sanitize.py — ROS name/type regex allowlists
- Wire into call_service (return error string on reject)
- Offline unit tests

## Verification
PYTHONPATH=llm_robot python3 -m unittest discover -s llm_robot/test -p 'test_ros_arg*.py' -v
6 tests OK offline.

## Notes
- Dual-agent aerial campaign: Composer 2.5 Standard intent / Bartok review
- Orthogonal to open #17–#20
