### PR TITLE
fix(robot): sanitize multi_robot robot_name for cmd_vel topics

### DIFF
--- a/llm_robot/llm_robot/multi_robot.py
+++ b/llm_robot/llm_robot/multi_robot.py
@@ -30,6 +30,7 @@ from std_msgs.msg import String
 from geometry_msgs.msg import Pose
 from geometry_msgs.msg import Twist
 from llm_interfaces.srv import ChatGPT
+from llm_robot.robot_name_sanitize import sanitize_robot_name
 
 # Global Initialization
 from llm_config.user_config import UserConfig
@@ -112,7 +113,10 @@ class MultiRobot(Node):
         Publishes cmd_vel message to control the movement of all types of robots
         """
         # Get parameters
-        robot_name = kwargs.get("robot_name", "")
+        ok, robot_name, name_err = sanitize_robot_name(kwargs.get("robot_name", ""))
+        if not ok:
+            self.get_logger().info(f"Rejected publish_cmd_vel: {name_err}")
+            return name_err
         duration = kwargs.get("duration", 0)
         linear_x = kwargs.get("linear_x", 0.0)
         linear_y = kwargs.get("linear_y", 0.0)

--- a/llm_robot/llm_robot/robot_name_sanitize.py
+++ b/llm_robot/llm_robot/robot_name_sanitize.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok9 (Aerial OSS campaign)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed robot_name for cmd_vel topic construction from LLM args.
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+# Empty string is allowed (maps to /cmd_vel). Non-empty: single ROS graph token.
+_ROBOT = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+
+
+def sanitize_robot_name(name: object) -> Tuple[bool, Optional[str], str]:
+    """
+    Returns (ok, sanitized_or_None, error_or_empty).
+    empty / None-like → ok with "" (default robot).
+    """
+    if name is None:
+        return True, "", ""
+    if not isinstance(name, str):
+        return False, None, "invalid robot_name"
+    if name == "":
+        return True, "", ""
+    if name.strip() == "" and name != "":
+        return False, None, "invalid robot_name"
+    if any(c.isspace() or c in "/;|&$`\\\"'<>." for c in name):
+        return False, None, "invalid robot_name"
+    if not _ROBOT.match(name):
+        return False, None, "invalid robot_name"
+    return True, name, ""

--- a/llm_robot/test/test_robot_name_sanitize.py
+++ b/llm_robot/test/test_robot_name_sanitize.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2026 Bartok9 (Aerial OSS campaign)
+# Licensed under the Apache License, Version 2.0
+
+import unittest
+
+from llm_robot.robot_name_sanitize import sanitize_robot_name
+
+
+class TestRobotNameSanitize(unittest.TestCase):
+    def test_empty_default(self):
+        ok, n, err = sanitize_robot_name("")
+        self.assertTrue(ok)
+        self.assertEqual(n, "")
+        self.assertEqual(err, "")
+
+    def test_none(self):
+        ok, n, err = sanitize_robot_name(None)
+        self.assertTrue(ok)
+        self.assertEqual(n, "")
+
+    def test_valid(self):
+        ok, n, _ = sanitize_robot_name("turtle1")
+        self.assertTrue(ok)
+        self.assertEqual(n, "turtle1")
+        ok, n, _ = sanitize_robot_name("minipupper")
+        self.assertTrue(ok)
+
+    def test_invalid(self):
+        for bad in ["../x", "a/b", "has space", "rm;id", 12, "x$y", ".hidden"]:
+            ok, n, err = sanitize_robot_name(bad)
+            self.assertFalse(ok, bad)
+            self.assertIsNone(n)
+            self.assertIn("invalid", err)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fail-closed whitelist for robot_name in MultiRobot.publish_cmd_vel before creating /{name}/cmd_vel publishers.

## Motivation
LLM function args can inject /, spaces, or shell-ish tokens into topic paths. Empty name still maps to default /cmd_vel.

## Changes
- llm_robot/robot_name_sanitize.py
- Early return on invalid names (no publisher create)
- Offline unit tests

## Verification
PYTHONPATH=llm_robot python3 -m unittest discover -s llm_robot/test -p 'test_robot_name*.py' -v

## Notes
- Dual-agent aerial campaign; Bartok review
- Orthogonal to open #17-#21
