### PR TITLE
fix(robot): allowlist LLM function_call method names

### DIFF
--- a/llm_robot/llm_robot/arx5_arm_robot.py
+++ b/llm_robot/llm_robot/arx5_arm_robot.py
@@ -41,6 +41,7 @@ from std_srvs.srv import Empty
 import json
 import os
 from llm_config.user_config import UserConfig
+from llm_robot.function_call_guard import resolve_function
 
 # Global Initialization
 config = UserConfig()
@@ -66,7 +67,12 @@ class ArmRobot(Node):
         req = json.loads(request.request_text)
         function_name = req["name"]
         function_args = json.loads(req["arguments"])
-        func_obj = getattr(self, function_name)
+        ok, name_or_err = resolve_function("arm", function_name)
+        if not ok:
+            self.get_logger().info(f"Rejected function call: {name_or_err}")
+            response.response_text = name_or_err
+            return response
+        func_obj = getattr(self, name_or_err)
         try:
             function_execution_result = func_obj(**function_args)
         except Exception as error:

--- a/llm_robot/llm_robot/function_call_guard.py
+++ b/llm_robot/llm_robot/function_call_guard.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (allowlist helper)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed allowlist for LLM-chosen function names before getattr.
+
+from __future__ import annotations
+
+from typing import Dict, FrozenSet, Set, Tuple
+
+# Methods the LLM may invoke via ChatGPT function-call JSON "name"
+ALLOWED_FUNCTIONS: Dict[str, FrozenSet[str]] = {
+    "multi": frozenset({"publish_cmd_vel", "call_service"}),
+    "turtle": frozenset({"publish_cmd_vel", "reset_turtlesim"}),
+    "arm": frozenset({"publish_target_pose"}),
+}
+
+
+def resolve_function(
+    robot_kind: str, function_name: object
+) -> Tuple[bool, str]:
+    """
+    Return (True, name) if function_name is an allowed action for robot_kind.
+    Otherwise (False, error_message).
+    """
+    if robot_kind not in ALLOWED_FUNCTIONS:
+        return False, f"unknown robot_kind for function allowlist: {robot_kind!r}"
+
+    if function_name is None:
+        return False, "function name is required"
+
+    if not isinstance(function_name, str):
+        return False, "function name must be a string"
+
+    name = function_name.strip()
+    if not name:
+        return False, "function name is empty"
+
+    # Path/self-injection / attribute walk
+    if any(ch in name for ch in (".", "/", "\\", " ", "\t", "\n", "\r")):
+        return False, f"invalid function name: {function_name!r}"
+
+    if name.startswith("_"):
+        return False, f"function name not allowed: {name!r}"
+
+    allowed: Set[str] = set(ALLOWED_FUNCTIONS[robot_kind])
+    if name not in allowed:
+        return False, f"function not in allowlist: {name!r}"
+
+    return True, name

--- a/llm_robot/llm_robot/multi_robot.py
+++ b/llm_robot/llm_robot/multi_robot.py
@@ -33,6 +33,7 @@ from llm_interfaces.srv import ChatGPT
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_robot.function_call_guard import resolve_function
 
 config = UserConfig()
 
@@ -83,7 +84,12 @@ class MultiRobot(Node):
         req = json.loads(request.request_text)
         function_name = req["name"]
         function_args = json.loads(req["arguments"])
-        func_obj = getattr(self, function_name)
+        ok, name_or_err = resolve_function("multi", function_name)
+        if not ok:
+            self.get_logger().info(f"Rejected function call: {name_or_err}")
+            response.response_text = name_or_err
+            return response
+        func_obj = getattr(self, name_or_err)
         try:
             function_execution_result = func_obj(**function_args)
         except Exception as error:

--- a/llm_robot/llm_robot/turtle_robot.py
+++ b/llm_robot/llm_robot/turtle_robot.py
@@ -40,6 +40,7 @@ from std_srvs.srv import Empty
 # LLM related
 import json
 from llm_config.user_config import UserConfig
+from llm_robot.function_call_guard import resolve_function
 
 # Global Initialization
 config = UserConfig()
@@ -66,7 +67,12 @@ class TurtleRobot(Node):
         req = json.loads(request.request_text)
         function_name = req["name"]
         function_args = json.loads(req["arguments"])
-        func_obj = getattr(self, function_name)
+        ok, name_or_err = resolve_function("turtle", function_name)
+        if not ok:
+            self.get_logger().info(f"Rejected function call: {name_or_err}")
+            response.response_text = name_or_err
+            return response
+        func_obj = getattr(self, name_or_err)
         try:
             function_execution_result = func_obj(**function_args)
         except Exception as error:

--- a/llm_robot/test/test_function_call_guard.py
+++ b/llm_robot/test/test_function_call_guard.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_robot.function_call_guard import resolve_function, ALLOWED_FUNCTIONS
+
+
+class TestFunctionCallGuard(unittest.TestCase):
+    def test_allow_known(self):
+        ok, name = resolve_function("turtle", "publish_cmd_vel")
+        self.assertTrue(ok)
+        self.assertEqual(name, "publish_cmd_vel")
+
+    def test_reject_destroy_node(self):
+        ok, err = resolve_function("turtle", "destroy_node")
+        self.assertFalse(ok)
+        self.assertIn("allowlist", err)
+
+    def test_reject_dunder(self):
+        ok, err = resolve_function("multi", "__class__")
+        self.assertFalse(ok)
+
+    def test_reject_path(self):
+        ok, err = resolve_function("multi", "publish_cmd_vel;rm")
+        self.assertFalse(ok)
+
+    def test_strip_whitespace_ok_name(self):
+        ok, name = resolve_function("arm", "  publish_target_pose  ")
+        self.assertTrue(ok)
+        self.assertEqual(name, "publish_target_pose")
+
+    def test_kinds_cover_demo_robots(self):
+        self.assertIn("multi", ALLOWED_FUNCTIONS)
+        self.assertIn("turtle", ALLOWED_FUNCTIONS)
+        self.assertIn("arm", ALLOWED_FUNCTIONS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
LLM function-call dispatch used `getattr(self, function_name)` with no name allowlist, so a crafted function payload could target unintended Node methods (lifecycle, internals).

This adds a small fail-closed allowlist helper and wires it into the multi / turtle / arx5 robot demos.

### Motivation
Embodied stacks should treat model-chosen tool names as untrusted input. Restricting dispatch keeps demos closer to intended robot actions (`publish_cmd_vel`, `call_service`, `reset_turtlesim`, `publish_target_pose`).

### Changes
- `llm_robot/function_call_guard.py` — `resolve_function(robot_kind, name)`
- Callbacks return a clear rejection string without `getattr` on deny
- Offline unit tests (no ROS runtime)

### Verification
```bash
PYTHONPATH=llm_robot python3 -m unittest discover -s llm_robot/test -p 'test_function_call_guard.py' -v
```

AI-assisted; human-reviewed. No third-party secrets in diff.