### PR TITLE
fix(robot): cap multi_robot cmd_vel publish duration

### DIFF
--- a/llm_robot/llm_robot/duration_sanitize.py
+++ b/llm_robot/llm_robot/duration_sanitize.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (duration helper)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed / clamped duration for LLM cmd_vel publish loops.
+
+from __future__ import annotations
+
+import math
+from typing import Union
+
+Number = Union[int, float]
+
+DEFAULT_MAX_DURATION_SEC = 30.0
+
+
+def sanitize_duration(
+    value: object, max_sec: float = DEFAULT_MAX_DURATION_SEC
+) -> float:
+    """
+    Return a non-negative duration in seconds, clamped to [0, max_sec].
+
+    Raises ValueError for non-numeric / non-finite / bool inputs.
+    """
+    if isinstance(value, bool) or value is None:
+        raise ValueError(f"duration must be a number, got {value!r}")
+    try:
+        duration = float(value)
+    except (TypeError, ValueError) as err:
+        raise ValueError(f"duration must be numeric: {value!r}") from err
+    if not math.isfinite(duration):
+        raise ValueError(f"duration must be finite: {value!r}")
+    if duration < 0:
+        raise ValueError(f"duration must be >= 0: {duration}")
+    if max_sec < 0 or not math.isfinite(max_sec):
+        raise ValueError(f"max_sec must be a finite non-negative number: {max_sec!r}")
+    if duration > max_sec:
+        return float(max_sec)
+    return float(duration)

--- a/llm_robot/llm_robot/multi_robot.py
+++ b/llm_robot/llm_robot/multi_robot.py
@@ -33,6 +33,7 @@ from llm_interfaces.srv import ChatGPT
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_robot.duration_sanitize import sanitize_duration
 
 config = UserConfig()
 
@@ -113,7 +114,11 @@ class MultiRobot(Node):
         """
         # Get parameters
         robot_name = kwargs.get("robot_name", "")
-        duration = kwargs.get("duration", 0)
+        try:
+            duration = sanitize_duration(kwargs.get("duration", 0))
+        except ValueError as err:
+            self.get_logger().info(f"Rejected publish_cmd_vel duration: {err}")
+            return str(err)
         linear_x = kwargs.get("linear_x", 0.0)
         linear_y = kwargs.get("linear_y", 0.0)
         linear_z = kwargs.get("linear_z", 0.0)

--- a/llm_robot/test/test_duration_sanitize.py
+++ b/llm_robot/test/test_duration_sanitize.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_robot.duration_sanitize import sanitize_duration, DEFAULT_MAX_DURATION_SEC
+
+
+class TestDurationSanitize(unittest.TestCase):
+    def test_zero(self):
+        self.assertEqual(sanitize_duration(0), 0.0)
+
+    def test_clamp_high(self):
+        self.assertEqual(sanitize_duration(9999), DEFAULT_MAX_DURATION_SEC)
+
+    def test_normal(self):
+        self.assertEqual(sanitize_duration(1.5), 1.5)
+
+    def test_reject_nan(self):
+        with self.assertRaises(ValueError):
+            sanitize_duration(float("nan"))
+
+    def test_reject_negative(self):
+        with self.assertRaises(ValueError):
+            sanitize_duration(-1)
+
+    def test_reject_bool(self):
+        with self.assertRaises(ValueError):
+            sanitize_duration(True)
+
+    def test_string_numeric(self):
+        self.assertEqual(sanitize_duration("2"), 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary
`MultiRobot.publish_cmd_vel` takes an LLM-supplied `duration` and blocks in a publish loop for that many seconds. There was no upper bound or non-finite guard.

### Motivation
A bad model argument (`1e12`, `inf`, negative nonsense cast runners) can hang the robot node. Cap and validate before publishing.

### Changes
- `duration_sanitize.sanitize_duration` — reject non-finite / negative / bool; clamp high values to 30s default
- Wire into multi_robot `publish_cmd_vel` only
- Offline unit tests

### Verification
```bash
PYTHONPATH=llm_robot python3 -m unittest discover -s llm_robot/test -p 'test_duration_sanitize.py' -v
```

AI-assisted; human-reviewed.