### PR TITLE
fix(model): sanitize ChatGPT function_call payloads before RPC

### DIFF
--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,6 +46,7 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.function_call_payload import sanitize_function_call
 
 
 # Global Initialization
@@ -256,10 +257,16 @@ class ChatGPTNode(Node):
         Sends a function call request with the given input and waits for the response.
         When the response is received, the function call response callback is called.
         """
-        # JSON object to string
-        function_call_input_str = json.dumps(function_call_input)
+        ok, normalized_or_err = sanitize_function_call(function_call_input)
+        if not ok:
+            self.get_logger().error(
+                f"Rejected ChatGPT function_call payload: {normalized_or_err}"
+            )
+            return
+        # JSON object to string (sanitized, serializable)
+        function_call_input_str = json.dumps(normalized_or_err)
         # Get function name
-        self.function_name = function_call_input["name"]
+        self.function_name = normalized_or_err["name"]
         # Send function call request
         self.function_call_requst.request_text = function_call_input_str
         self.get_logger().info(
@@ -315,9 +322,18 @@ class ChatGPTNode(Node):
         message, text, function_call, function_flag = self.get_response_information(
             chatgpt_response
         )
-        # Append response to chat history
+        # Append response to chat history (JSON-serializable function_call only)
+        history_function_call = None
+        if function_call is not None:
+            ok_fc, normalized_fc = sanitize_function_call(function_call)
+            if ok_fc:
+                history_function_call = normalized_fc
+            else:
+                self.get_logger().error(
+                    f"Omitting unsanitized function_call from history: {normalized_fc}"
+                )
         self.add_message_to_history(
-            role="assistant", content=text, function_call=function_call
+            role="assistant", content=text, function_call=history_function_call
         )
         # Write chat history to JSON
         self.write_chat_history_to_json()

--- a/llm_model/llm_model/function_call_payload.py
+++ b/llm_model/llm_model/function_call_payload.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (function_call payload sanitize)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed sanitizer for OpenAI-style function_call objects before ROS RPC.
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Tuple, Union
+
+_Ok = bool
+_Normalized = Dict[str, str]
+_Err = str
+
+
+def _get_field(obj: Any, key: str) -> Any:
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(key)
+    # openai SDK objects often support mapping-style or attribute access
+    try:
+        if hasattr(obj, "get"):
+            return obj.get(key)
+    except Exception:
+        pass
+    return getattr(obj, key, None)
+
+
+def sanitize_function_call(obj: Any) -> Tuple[_Ok, Union[_Normalized, _Err]]:
+    """
+    Validate and normalize a ChatCompletions function_call payload.
+
+    Returns (True, {"name": str, "arguments": str}) where arguments is a JSON object
+    string, or (False, error_message).
+    """
+    if obj is None:
+        return False, "function_call is required"
+
+    name_raw = _get_field(obj, "name")
+    if name_raw is None:
+        return False, "function_call.name is required"
+    if not isinstance(name_raw, str):
+        return False, "function_call.name must be a string"
+
+    name = name_raw.strip()
+    if not name:
+        return False, "function_call.name is empty"
+
+    if any(ch in name for ch in (".", "/", "\\", " ", "\t", "\n", "\r")):
+        return False, f"invalid function_call.name: {name_raw!r}"
+
+    if name.startswith("_"):
+        return False, f"function_call.name not allowed: {name!r}"
+
+    args_raw = _get_field(obj, "arguments")
+    if args_raw is None:
+        args_str = "{}"
+    elif isinstance(args_raw, dict):
+        try:
+            args_str = json.dumps(args_raw)
+        except (TypeError, ValueError) as err:
+            return False, f"function_call.arguments not JSON-serializable: {err}"
+    elif isinstance(args_raw, str):
+        text = args_raw.strip()
+        if not text:
+            args_str = "{}"
+        else:
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as err:
+                return False, f"function_call.arguments is not valid JSON: {err}"
+            if not isinstance(parsed, dict):
+                return False, "function_call.arguments JSON must be an object"
+            args_str = json.dumps(parsed)
+    else:
+        return False, "function_call.arguments must be a string or object"
+
+    return True, {"name": name, "arguments": args_str}

--- a/llm_model/test/test_function_call_payload.py
+++ b/llm_model/test/test_function_call_payload.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+
+import json
+import os
+import sys
+import unittest
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from llm_model.function_call_payload import sanitize_function_call  # noqa: E402
+
+
+class TestSanitizeFunctionCall(unittest.TestCase):
+    def test_ok_dict_string_args(self):
+        ok, out = sanitize_function_call(
+            {"name": "publish_cmd_vel", "arguments": '{"linear_x": 0.1}'}
+        )
+        self.assertTrue(ok)
+        self.assertEqual(out["name"], "publish_cmd_vel")
+        self.assertEqual(json.loads(out["arguments"])["linear_x"], 0.1)
+
+    def test_ok_dict_object_args(self):
+        ok, out = sanitize_function_call(
+            {"name": "call_service", "arguments": {"service_name": "/reset"}}
+        )
+        self.assertTrue(ok)
+        self.assertEqual(json.loads(out["arguments"])["service_name"], "/reset")
+
+    def test_ok_none_args_default_empty_object(self):
+        ok, out = sanitize_function_call({"name": "publish_cmd_vel"})
+        self.assertTrue(ok)
+        self.assertEqual(out["arguments"], "{}")
+
+    def test_reject_empty_name(self):
+        ok, err = sanitize_function_call({"name": "  ", "arguments": "{}"})
+        self.assertFalse(ok)
+        self.assertIn("empty", err)
+
+    def test_reject_path_like_name(self):
+        ok, err = sanitize_function_call({"name": "os.system", "arguments": "{}"})
+        self.assertFalse(ok)
+
+    def test_reject_dunder_name(self):
+        ok, err = sanitize_function_call({"name": "__init__", "arguments": "{}"})
+        self.assertFalse(ok)
+
+    def test_reject_non_object_json_args(self):
+        ok, err = sanitize_function_call(
+            {"name": "publish_cmd_vel", "arguments": "[1,2]"}
+        )
+        self.assertFalse(ok)
+
+    def test_reject_invalid_json_string(self):
+        ok, err = sanitize_function_call(
+            {"name": "publish_cmd_vel", "arguments": "{not-json"}
+        )
+        self.assertFalse(ok)
+
+    def test_attr_style_object(self):
+        class FC:
+            def __init__(self):
+                self.name = "publish_cmd_vel"
+                self.arguments = "{}"
+
+        ok, out = sanitize_function_call(FC())
+        self.assertTrue(ok)
+        self.assertEqual(out["name"], "publish_cmd_vel")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
OpenAI `function_call` objects are passed through `json.dumps` and into the robot function-call service without validation. Malformed names/arguments can crash the model node or forward unsafe RPC payloads.

This change adds a small fail-closed sanitizer and uses it before the ROS service call and when writing chat history (JSON-serializable dict only).

## Changes
- `llm_model/function_call_payload.py` — name/arguments guards
- Wire `ChatGPTNode.function_call` + history append
- Offline unit tests (`test_function_call_payload.py`)

## Test plan
- [x] `PYTHONPATH=llm_model:llm_config python3 -m unittest discover -s llm_model/test -p 'test_function_call_payload.py' -v`

AI-assisted; human-reviewed. Orthogonal to open robot-side security PRs (#17–#24).