### PR TITLE
fix(input): clamp AWS audio recording duration/sample_rate/gain

### DIFF
--- a/llm_input/llm_input/audio_params.py
+++ b/llm_input/llm_input/audio_params.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (audio recording param clamp)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed clamps for sounddevice recording parameters.
+
+from __future__ import annotations
+
+import math
+from typing import Any, Tuple, Union
+
+_COMMON_RATES = frozenset({8000, 11025, 16000, 22050, 32000, 44100, 48000})
+_MIN_RATE = 8000
+_MAX_RATE = 48000
+_MAX_DURATION = 60.0
+_MAX_GAIN = 10.0
+
+
+def _as_finite_float(value: Any, label: str) -> Tuple[bool, Union[float, str]]:
+    if isinstance(value, bool):
+        return False, f"{label} must not be bool"
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return False, f"{label} must be a number"
+    if not math.isfinite(number):
+        return False, f"{label} must be finite"
+    return True, number
+
+
+def sanitize_recording_params(
+    duration: Any,
+    sample_rate: Any,
+    volume_gain_multiplier: Any,
+) -> Tuple[bool, float, int, float, str]:
+    """
+    Validate recording knobs before allocating audio buffers.
+
+    Returns (ok, duration, sample_rate, gain, err). On failure ok is False and
+    err explains why; numeric fields may be placeholders.
+    """
+    ok_d, duration_or_err = _as_finite_float(duration, "duration")
+    if not ok_d:
+        return False, 0.0, 0, 0.0, str(duration_or_err)
+    duration_f = float(duration_or_err)
+    if duration_f <= 0.0 or duration_f > _MAX_DURATION:
+        return (
+            False,
+            0.0,
+            0,
+            0.0,
+            f"duration must be in (0, {_MAX_DURATION:g}] seconds",
+        )
+
+    if isinstance(sample_rate, bool):
+        return False, 0.0, 0, 0.0, "sample_rate must not be bool"
+    try:
+        # reject non-integer floats like 16000.5
+        if isinstance(sample_rate, float) and not sample_rate.is_integer():
+            return False, 0.0, 0, 0.0, "sample_rate must be an integer Hz value"
+        rate_i = int(sample_rate)
+    except (TypeError, ValueError):
+        return False, 0.0, 0, 0.0, "sample_rate must be an integer"
+
+    if rate_i in _COMMON_RATES:
+        pass
+    elif _MIN_RATE <= rate_i <= _MAX_RATE:
+        pass
+    else:
+        return (
+            False,
+            0.0,
+            0,
+            0.0,
+            f"sample_rate must be between {_MIN_RATE} and {_MAX_RATE} Hz",
+        )
+
+    ok_g, gain_or_err = _as_finite_float(volume_gain_multiplier, "volume_gain_multiplier")
+    if not ok_g:
+        return False, 0.0, 0, 0.0, str(gain_or_err)
+    gain_f = float(gain_or_err)
+    if gain_f <= 0.0 or gain_f > _MAX_GAIN:
+        return (
+            False,
+            0.0,
+            0,
+            0.0,
+            f"volume_gain_multiplier must be in (0, {_MAX_GAIN:g}]",
+        )
+
+    return True, duration_f, rate_i, gain_f, ""

--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.audio_params import sanitize_recording_params
 
 config = UserConfig()
 
@@ -89,10 +90,20 @@ class AudioInput(Node):
             self.action_function_listening()
 
     def action_function_listening(self):
-        # Recording settings
-        duration = config.duration  # Audio recording duration, in seconds
-        sample_rate = config.sample_rate  # Sample rate
-        volume_gain_multiplier = config.volume_gain_multiplier  # Volume gain multiplier
+        # Recording settings (fail-closed clamp before buffer allocation)
+        ok_params, duration, sample_rate, volume_gain_multiplier, param_err = (
+            sanitize_recording_params(
+                config.duration,
+                config.sample_rate,
+                config.volume_gain_multiplier,
+            )
+        )
+        if not ok_params:
+            self.get_logger().error(
+                f"Rejected audio recording parameters: {param_err}"
+            )
+            self.publish_string("listening", self.llm_state_publisher)
+            return
         # AWS S3 settings
         bucket_name = config.bucket_name
         audio_file_key = "gpt_audio.flac"  # Name of the audio file in S3

--- a/llm_input/test/test_audio_params.py
+++ b/llm_input/test/test_audio_params.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# flake8: noqa
+
+import os
+import sys
+import unittest
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from llm_input.audio_params import sanitize_recording_params  # noqa: E402
+
+
+class TestSanitizeRecordingParams(unittest.TestCase):
+    def test_ok_defaults(self):
+        ok, d, sr, g, err = sanitize_recording_params(5, 16000, 1)
+        self.assertTrue(ok)
+        self.assertEqual(d, 5.0)
+        self.assertEqual(sr, 16000)
+        self.assertEqual(g, 1.0)
+        self.assertEqual(err, "")
+
+    def test_reject_zero_duration(self):
+        ok, *_rest = sanitize_recording_params(0, 16000, 1)
+        self.assertFalse(ok)
+
+    def test_reject_huge_duration(self):
+        ok, *_rest = sanitize_recording_params(3600, 16000, 1)
+        self.assertFalse(ok)
+
+    def test_reject_nan_duration(self):
+        ok, *_rest = sanitize_recording_params(float("nan"), 16000, 1)
+        self.assertFalse(ok)
+
+    def test_reject_low_sample_rate(self):
+        ok, *_rest = sanitize_recording_params(5, 100, 1)
+        self.assertFalse(ok)
+
+    def test_reject_bool_sample_rate(self):
+        ok, *_rest = sanitize_recording_params(5, True, 1)
+        self.assertFalse(ok)
+
+    def test_reject_gain_zero(self):
+        ok, *_rest = sanitize_recording_params(5, 16000, 0)
+        self.assertFalse(ok)
+
+    def test_reject_gain_high(self):
+        ok, *_rest = sanitize_recording_params(5, 16000, 50)
+        self.assertFalse(ok)
+
+    def test_ok_upper_bounds(self):
+        ok, d, sr, g, err = sanitize_recording_params(60, 48000, 10)
+        self.assertTrue(ok)
+        self.assertEqual((d, sr, g), (60.0, 48000, 10.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why
`llm_audio_input` allocates the recording buffer with `int(duration * sample_rate)`. Misconfigured `UserConfig` values (non-finite duration, huge sample rate / gain) can blow memory or hang the audio path.

## What
- Add `sanitize_recording_params` with strict positive bounds
- Gate `action_function_listening` before `sounddevice.rec`
- Offline unit tests (no AWS / sounddevice needed)

## Defaults
Stock config (`duration=5`, `sample_rate=16000`, `gain=1`) remains valid.

## Test plan
- [x] `PYTHONPATH=llm_input python3 -m unittest discover -s llm_input/test -p 'test_audio_params.py' -v`

Path touch: `llm_input` only — no overlap with open #17–#24 robot package PRs.