### PR TITLE
fix(output): sanitize Polly voice id and avoid shell mpv

### DIFF
--- a/llm_output/llm_output/llm_audio_output.py
+++ b/llm_output/llm_output/llm_audio_output.py
@@ -29,6 +29,12 @@ import datetime
 import json
 import requests
 import time
+import subprocess
+
+from llm_output.polly_sanitize import (
+    sanitize_feedback_text,
+    sanitize_polly_voice_id,
+)
 
 # AWS ASR related
 import boto3
@@ -81,19 +87,36 @@ class AudioOutput(Node):
     def feedback_for_user_callback(self, msg):
         self.get_logger().info("Received text: '%s'" % msg.data)
 
+        ok_text, text_or_err = sanitize_feedback_text(msg.data)
+        if not ok_text:
+            self.get_logger().warn(
+                "Skipping Polly synthesize: %s" % text_or_err
+            )
+            self.publish_string("listening", self.llm_state_publisher)
+            return
+
+        voice_id = sanitize_polly_voice_id(config.aws_voice_id)
+
         # Call AWS Polly service to synthesize speech
         polly_client = self.aws_session.client("polly")
         self.get_logger().info("Polly client successfully initialized.")
         response = polly_client.synthesize_speech(
-            Text=msg.data, OutputFormat="mp3", VoiceId=config.aws_voice_id
+            Text=text_or_err, OutputFormat="mp3", VoiceId=voice_id
         )
 
         # Save the audio output to a file
         output_file_path = "/tmp/speech_output.mp3"
         with open(output_file_path, "wb") as file:
             file.write(response["AudioStream"].read())
-        # Play the audio output
-        os.system("mpv" + " " + output_file_path)
+        # Play the audio output without a shell (avoid injection)
+        try:
+            subprocess.run(
+                ["mpv", "--", output_file_path],
+                check=False,
+                timeout=120,
+            )
+        except Exception as exc:
+            self.get_logger().error("mpv playback failed: %s" % exc)
         self.get_logger().info("Finished Polly playing.")
         self.publish_string("feedback finished", self.llm_state_publisher)
         self.publish_string("listening", self.llm_state_publisher)

--- a/llm_output/llm_output/polly_sanitize.py
+++ b/llm_output/llm_output/polly_sanitize.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Daniel Pike / Bartok9 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fail-closed helpers for AWS Polly voice ids and TTS feedback text."""
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+# Common Polly standard / neural voices used in ROS-LLM and docs (Ivy, Zhiyu - zh).
+ALLOWED_POLLY_VOICES = frozenset(
+    {
+        "Ivy",
+        "Joanna",
+        "Joey",
+        "Justin",
+        "Kendra",
+        "Kimberly",
+        "Matthew",
+        "Salli",
+        "Amy",
+        "Emma",
+        "Brian",
+        "Aditi",
+        "Raveena",
+        "Zhiyu",
+        "Laura",
+        "Ruth",
+        "Stephen",
+        "Lucia",
+        "Lea",
+        "Vicki",
+        "Hans",
+        "Marlene",
+        "Mizuki",
+        "Takumi",
+        "Seoyeon",
+        "Camila",
+        "Lupe",
+        "Mia",
+        "Pedro",
+        "Andres",
+        "Sergio",
+        "Bianca",
+        "Carla",
+        "Giorgio",
+        "Celine",
+        "Mathieu",
+        "Chantal",
+        "Vitória",
+        "Camila",
+        "Ricardo",
+        "Ines",
+        "Cristiano",
+        "Carmen",
+        "Enrique",
+        "Conchita",
+        "Naja",
+        "Mads",
+        "Ruben",
+        "Lotte",
+        "Astrid",
+        "Filiz",
+        "Jacek",
+        "Jan",
+        "Ewa",
+        "Maja",
+        "Karl",
+        "Dora",
+        "Liv",
+        "Tatyana",
+        "Maxim",
+        "Gwyneth",
+        "Geraint",
+        "Nicole",
+        "Russell",
+        "Olivia",
+        "Aria",
+        "Ayanda",
+        "Kajal",
+        "Hiujin",
+        "Zayd",
+        "Hala",
+        "Arlet",
+        "Hannah",
+        "Sofie",
+        "Ida",
+        "Niamh",
+        "Danielle",
+        "Gregory",
+        "Kevin",
+        "Arthur",
+        "Kajal",
+        "Ola",
+        "Suvi",
+        "Lisa",
+        "Adriano",
+        "Thiago",
+        "Andres",
+        "Sergio",
+        "Lucia",
+        "Sergio",
+        "Isabelle",
+        "Kazuha",
+        "Tomoko",
+        "Jihye",
+        "Seoyeon",
+    }
+)
+
+_CTRL = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def sanitize_polly_voice_id(raw, default: str = "Ivy") -> str:
+    """Return an allowlisted Polly VoiceId or ``default``."""
+    if default not in ALLOWED_POLLY_VOICES:
+        default = "Ivy"
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        return default
+    voice = raw.strip()
+    if not voice or _CTRL.search(voice):
+        return default
+    if any(sep in voice for sep in ("/", "\\", " ", "\t", ";", "|", "&", "$", "`")):
+        return default
+    if voice not in ALLOWED_POLLY_VOICES:
+        return default
+    return voice
+
+
+def sanitize_feedback_text(raw, max_len: int = 3000) -> Tuple[bool, str]:
+    """Require non-empty user-facing TTS text; cap length; reject NUL."""
+    if raw is None:
+        return False, "empty_feedback"
+    if not isinstance(raw, str):
+        try:
+            raw = str(raw)
+        except Exception:
+            return False, "invalid_feedback_type"
+    text = raw.replace("\x00", "").strip()
+    if not text:
+        return False, "empty_feedback"
+    if max_len is not None and max_len > 0 and len(text) > max_len:
+        text = text[:max_len]
+    return True, text

--- a/llm_output/test/test_polly_sanitize.py
+++ b/llm_output/test/test_polly_sanitize.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline tests for Polly TTS sanitizers."""
+
+import unittest
+
+from llm_output.polly_sanitize import (
+    sanitize_feedback_text,
+    sanitize_polly_voice_id,
+)
+
+
+class TestPollySanitize(unittest.TestCase):
+    def test_voice_allowlist(self):
+        self.assertEqual(sanitize_polly_voice_id("Ivy"), "Ivy")
+        self.assertEqual(sanitize_polly_voice_id("Zhiyu"), "Zhiyu")
+        self.assertEqual(sanitize_polly_voice_id("not-a-voice"), "Ivy")
+        self.assertEqual(sanitize_polly_voice_id("../etc"), "Ivy")
+        self.assertEqual(sanitize_polly_voice_id("Ivy; rm -rf"), "Ivy")
+        self.assertEqual(sanitize_polly_voice_id(None, default="Matthew"), "Matthew")
+        self.assertEqual(sanitize_polly_voice_id("  Joanna  "), "Joanna")
+
+    def test_feedback_text(self):
+        ok, t = sanitize_feedback_text("Hello robot")
+        self.assertTrue(ok)
+        self.assertEqual(t, "Hello robot")
+        ok, err = sanitize_feedback_text("   ")
+        self.assertFalse(ok)
+        self.assertEqual(err, "empty_feedback")
+        ok, t = sanitize_feedback_text("x" * 5000, max_len=10)
+        self.assertTrue(ok)
+        self.assertEqual(len(t), 10)
+        ok, t = sanitize_feedback_text("a\x00b")
+        self.assertTrue(ok)
+        self.assertEqual(t, "ab")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
AWS Polly TTS accepts a free-form `VoiceId` from config and previously played audio via `os.system("mpv " + path)`. This PR allowlists known Polly voice ids (fallback Ivy), rejects empty feedback strings, and runs `mpv` with a list argv (no shell).

## Motivation
Avoid invalid Polly API calls and reduce shell-injection surface on the audio output path. AI-assisted; human-reviewed.

## Verification
```bash
PYTHONPATH=llm_output:llm_config python3 -m unittest discover -s llm_output/test -p 'test_polly_sanitize.py' -v
```