### PR TITLE
fix(input): whitelist Whisper model size and language

### DIFF
--- a/llm_input/llm_input/llm_audio_input_local.py
+++ b/llm_input/llm_input/llm_audio_input_local.py
@@ -28,6 +28,10 @@
 
 # Open Whisper related
 import whisper
+from llm_input.whisper_params import (
+    sanitize_whisper_language,
+    sanitize_whisper_model_size,
+)
 
 # Audio recording related
 import sounddevice as sd
@@ -98,13 +102,17 @@ class AudioInput(Node):
         self.publish_string("input_processing", self.llm_state_publisher)
 
         # Step 4: Process audio with OpenAI Whisper
-        whisper_model = whisper.load_model(config.whisper_model_size)
+        model_size = sanitize_whisper_model_size(config.whisper_model_size)
+        whisper_language = sanitize_whisper_language(config.whisper_language)
+        whisper_model = whisper.load_model(model_size)
 
         # Step 6: Wait until the conversion is complete
         self.get_logger().info("Local Converting...")
 
         # Step 7: Get the transcribed text
-        whisper_result = whisper_model.transcribe(self.tmp_audio_file,language=config.whisper_language)
+        whisper_result = whisper_model.transcribe(
+            self.tmp_audio_file, language=whisper_language
+        )
 
         transcript_text = whisper_result["text"]
         self.get_logger().info("Audio to text conversion complete!")

--- a/llm_input/llm_input/whisper_params.py
+++ b/llm_input/llm_input/whisper_params.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Daniel Pike / Bartok9 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fail-closed helpers for OpenAI Whisper model size and language."""
+
+from __future__ import annotations
+
+import re
+
+ALLOWED_WHISPER_SIZES = frozenset(
+    {
+        "tiny",
+        "base",
+        "small",
+        "medium",
+        "large",
+        "tiny.en",
+        "base.en",
+        "small.en",
+        "medium.en",
+        "large-v1",
+        "large-v2",
+        "large-v3",
+    }
+)
+
+_LANG_RE = re.compile(r"^[a-z]{2}(-[a-z]{2})?$")
+_CTRL = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def sanitize_whisper_model_size(raw, default: str = "base") -> str:
+    """Return an allowlisted Whisper model size name."""
+    if default not in ALLOWED_WHISPER_SIZES:
+        default = "base"
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        return default
+    size = raw.strip().lower()
+    if not size or _CTRL.search(size):
+        return default
+    if any(sep in size for sep in ("/", "\\", " ", "\t", ";", "|", "&", "$", "`", "..")):
+        return default
+    if size not in ALLOWED_WHISPER_SIZES:
+        return default
+    return size
+
+
+def sanitize_whisper_language(raw, default: str = "en") -> str:
+    """Return a safe short language code for whisper.transcribe."""
+    if not isinstance(default, str) or not default:
+        default = "en"
+    default = default.strip().lower()
+    if default != "auto" and not _LANG_RE.match(default):
+        default = "en"
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        return default
+    lang = raw.strip().lower().replace("_", "-")
+    if not lang or _CTRL.search(lang) or len(lang) > 8:
+        return default
+    if any(sep in lang for sep in ("/", "\\", " ", "\t", ";", "|", "&", "$", "`", "..")):
+        return default
+    if lang == "auto":
+        return "auto"
+    if not _LANG_RE.match(lang):
+        return default
+    return lang

--- a/llm_input/test/test_whisper_params.py
+++ b/llm_input/test/test_whisper_params.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline tests for Whisper model/language sanitizers."""
+
+import unittest
+
+from llm_input.whisper_params import (
+    sanitize_whisper_language,
+    sanitize_whisper_model_size,
+)
+
+
+class TestWhisperParams(unittest.TestCase):
+    def test_model_size(self):
+        self.assertEqual(sanitize_whisper_model_size("medium"), "medium")
+        self.assertEqual(sanitize_whisper_model_size("LARGE-V3"), "large-v3")
+        self.assertEqual(sanitize_whisper_model_size("turbo"), "base")
+        self.assertEqual(sanitize_whisper_model_size("../x"), "base")
+        self.assertEqual(sanitize_whisper_model_size(None, default="small"), "small")
+        self.assertEqual(sanitize_whisper_model_size("  Base  "), "base")
+
+    def test_language(self):
+        self.assertEqual(sanitize_whisper_language("en"), "en")
+        self.assertEqual(sanitize_whisper_language("EN-US"), "en-us")
+        self.assertEqual(sanitize_whisper_language("zh"), "zh")
+        self.assertEqual(sanitize_whisper_language("auto"), "auto")
+        self.assertEqual(sanitize_whisper_language("english"), "en")
+        self.assertEqual(sanitize_whisper_language("en;rm"), "en")
+        self.assertEqual(sanitize_whisper_language(None, default="zh"), "zh")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Local Whisper STT now routes `whisper_model_size` and `whisper_language` through allowlist sanitizers before `load_model` / `transcribe`, rejecting path-like or unknown sizes and malformed language codes.

## Motivation
Misconfigured or hostile config values should fail closed to `base`/`en` rather than passing arbitrary strings into the model loader. AI-assisted; human-reviewed.

## Verification
```bash
PYTHONPATH=llm_input:llm_config python3 -m unittest discover -s llm_input/test -p 'test_whisper_params.py' -v
```