### PR TITLE
fix(input): whitelist AWS Transcribe language codes

### DIFF
--- a/llm_input/llm_input/aws_transcribe_params.py
+++ b/llm_input/llm_input/aws_transcribe_params.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sanitize AWS Transcribe LanguageCode values from config."""
+
+from __future__ import annotations
+
+ALLOWED_AWS_TRANSCRIBE_LANG = frozenset(
+    {
+        "en-US",
+        "en-GB",
+        "en-AU",
+        "en-IN",
+        "en-IE",
+        "en-NZ",
+        "en-AB",
+        "en-WL",
+        "zh-CN",
+        "zh-TW",
+        "ja-JP",
+        "ko-KR",
+        "de-DE",
+        "de-CH",
+        "fr-FR",
+        "fr-CA",
+        "es-US",
+        "es-ES",
+        "pt-BR",
+        "pt-PT",
+        "it-IT",
+        "hi-IN",
+        "ar-SA",
+        "ar-AE",
+        "nl-NL",
+        "ru-RU",
+        "tr-TR",
+        "th-TH",
+        "vi-VN",
+        "id-ID",
+        "ms-MY",
+        "ta-IN",
+        "te-IN",
+        "he-IL",
+        "fa-IR",
+        "sv-SE",
+        "no-NO",
+        "da-DK",
+        "fi-FI",
+        "pl-PL",
+        "uk-UA",
+        "cs-CZ",
+        "ro-RO",
+        "hu-HU",
+        "el-GR",
+        "ca-ES",
+        "af-ZA",
+    }
+)
+
+
+def sanitize_aws_transcribe_language(raw, default="en-US"):
+    """Return an allowed Transcribe LanguageCode or *default*."""
+    if default not in ALLOWED_AWS_TRANSCRIBE_LANG:
+        default = "en-US"
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        return default
+    text = raw.strip()
+    if not text:
+        return default
+    if any(ch in text for ch in ("/", "\\", "\x00", "\n", "\r", "\t", " ", "..")):
+        return default
+    if text not in ALLOWED_AWS_TRANSCRIBE_LANG:
+        return default
+    return text

--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.aws_transcribe_params import sanitize_aws_transcribe_language
 
 config = UserConfig()
 
@@ -131,7 +132,9 @@ class AudioInput(Node):
         self.get_logger().info("Converting audio to text...")
         transcribe.start_transcription_job(
             TranscriptionJobName=transcribe_job_name,
-            LanguageCode=config.aws_transcription_language,
+            LanguageCode=sanitize_aws_transcribe_language(
+                config.aws_transcription_language
+            ),
             Media={"MediaFileUri": transcribe_job_uri},
         )
 

--- a/llm_input/test/test_aws_transcribe_params.py
+++ b/llm_input/test/test_aws_transcribe_params.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_input.aws_transcribe_params import (
+    ALLOWED_AWS_TRANSCRIBE_LANG,
+    sanitize_aws_transcribe_language,
+)
+
+
+class TestAwsTranscribeParams(unittest.TestCase):
+    def test_default_en_us(self):
+        self.assertEqual(sanitize_aws_transcribe_language(None), "en-US")
+        self.assertEqual(sanitize_aws_transcribe_language(""), "en-US")
+        self.assertEqual(sanitize_aws_transcribe_language("   "), "en-US")
+
+    def test_allowed(self):
+        self.assertEqual(sanitize_aws_transcribe_language("zh-CN"), "zh-CN")
+        self.assertEqual(sanitize_aws_transcribe_language("en-US"), "en-US")
+        self.assertIn("ja-JP", ALLOWED_AWS_TRANSCRIBE_LANG)
+
+    def test_reject_path_and_unknown(self):
+        self.assertEqual(sanitize_aws_transcribe_language("../evil"), "en-US")
+        self.assertEqual(sanitize_aws_transcribe_language("en-US/../../x"), "en-US")
+        self.assertEqual(sanitize_aws_transcribe_language("not-a-lang"), "en-US")
+        self.assertEqual(sanitize_aws_transcribe_language("EN-US"), "en-US")  # case
+        self.assertEqual(sanitize_aws_transcribe_language(123), "en-US")
+        self.assertEqual(sanitize_aws_transcribe_language("zh-CN\n"), "zh-CN")
+
+    def test_custom_default(self):
+        self.assertEqual(
+            sanitize_aws_transcribe_language("nope", default="zh-CN"), "zh-CN"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Whitelists AWS Transcribe `LanguageCode` values before `start_transcription_job` so misconfigured or hostile config cannot pass path-like / unknown codes into the AWS API.

## Changes
- New `llm_input.aws_transcribe_params.sanitize_aws_transcribe_language`
- Wire in `llm_audio_input.AudioInput.action_function_listening`
- Offline unit tests

## Test plan
- [x] `PYTHONPATH=llm_input python3 -m unittest discover -s llm_input/test -p 'test_aws_transcribe_params.py' -v`

AI-assisted; human-reviewed. Supercedes nothing; orthogonal to open Bartok9 secure-path PRs on audio duration/Whisper/Polly.