### PR TITLE
fix(model): sanitize OpenAI model id and chat history bounds

### DIFF
--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,6 +46,11 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.openai_model_params import (
+    clamp_chat_history_max_length,
+    safe_chat_history_filename,
+    sanitize_openai_model_id,
+)
 
 
 # Global Initialization
@@ -111,7 +116,14 @@ class ChatGPTNode(Node):
         # exceeding token limit, waiting to update @Herman Ye
         self.start_timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
         self.chat_history_file = os.path.join(
-            config.chat_history_path, f"chat_history_{self.start_timestamp}.json"
+            config.chat_history_path,
+            safe_chat_history_filename(self.start_timestamp),
+        )
+        self.chat_history_max_length = clamp_chat_history_max_length(
+            getattr(config, "chat_history_max_length", 4000)
+        )
+        self.openai_model = sanitize_openai_model_id(
+            getattr(config, "openai_model", None)
         )
         self.write_chat_history_to_json()
         self.get_logger().info(f"Chat history saved to {self.chat_history_file}")
@@ -162,7 +174,7 @@ class ChatGPTNode(Node):
         # Log
         self.get_logger().info(f"Chat history updated with {message_element_object}")
         # Checking if chat history is too long
-        if len(config.chat_history) > config.chat_history_max_length:
+        if len(config.chat_history) > self.chat_history_max_length:
             self.get_logger().info(
                 f"Chat history is too long, popping the oldest message: {config.chat_history[0]}"
             )
@@ -179,7 +191,7 @@ class ChatGPTNode(Node):
         # Log
         self.get_logger().info(f"Sending messages to OpenAI: {messages_input}")
         response = openai.ChatCompletion.create(
-            model=config.openai_model,
+            model=self.openai_model,
             messages=messages_input,
             functions=config.robot_functions_list,
             function_call="auto",

--- a/llm_model/llm_model/openai_model_params.py
+++ b/llm_model/llm_model/openai_model_params.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sanitize OpenAI model ids and chat-history write bounds."""
+
+from __future__ import annotations
+
+import math
+import re
+
+_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,63}$")
+_TS_RE = re.compile(r"^[0-9A-Za-z_\-]{1,64}$")
+
+
+def sanitize_openai_model_id(raw, default="gpt-3.5-turbo-0613"):
+    """Return a safe OpenAI model id string or *default*."""
+    if not isinstance(default, str) or not _MODEL_RE.match(default or ""):
+        default = "gpt-3.5-turbo-0613"
+    if raw is None:
+        return default
+    if not isinstance(raw, str):
+        return default
+    text = raw.strip()
+    if not text or ".." in text or "/" in text or "\\" in text:
+        return default
+    if any(ord(ch) < 32 for ch in text):
+        return default
+    if not _MODEL_RE.match(text):
+        return default
+    return text
+
+
+def clamp_chat_history_max_length(raw, default=4000, min_v=1, max_v=16000):
+    """Clamp chat history max length to a positive int window."""
+    if isinstance(raw, bool) or raw is None:
+        return int(default)
+    try:
+        if isinstance(raw, float) and (math.isnan(raw) or math.isinf(raw)):
+            return int(default)
+        value = int(raw)
+    except (TypeError, ValueError):
+        return int(default)
+    if value < int(min_v):
+        return int(min_v)
+    if value > int(max_v):
+        return int(max_v)
+    return value
+
+
+def safe_chat_history_filename(prefix_ts: str, prefix="chat_history_", suffix=".json"):
+    """Build a basename-only chat history file name from a timestamp fragment."""
+    if not isinstance(prefix_ts, str):
+        prefix_ts = "unknown"
+    frag = prefix_ts.strip().replace(" ", "-")
+    if not frag or ".." in frag or "/" in frag or "\\" in frag:
+        frag = "unknown"
+    if any(ord(ch) < 32 for ch in frag):
+        frag = "unknown"
+    if not _TS_RE.match(frag):
+        frag = "unknown"
+    return f"{prefix}{frag}{suffix}"

--- a/llm_model/test/test_openai_model_params.py
+++ b/llm_model/test/test_openai_model_params.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_model.openai_model_params import (
+    clamp_chat_history_max_length,
+    safe_chat_history_filename,
+    sanitize_openai_model_id,
+)
+
+
+class TestOpenAIModelParams(unittest.TestCase):
+    def test_model_ok(self):
+        self.assertEqual(
+            sanitize_openai_model_id("gpt-4-0613"), "gpt-4-0613"
+        )
+        self.assertEqual(
+            sanitize_openai_model_id("gpt-3.5-turbo-0613"),
+            "gpt-3.5-turbo-0613",
+        )
+
+    def test_model_reject(self):
+        self.assertEqual(
+            sanitize_openai_model_id("../x"), "gpt-3.5-turbo-0613"
+        )
+        self.assertEqual(
+            sanitize_openai_model_id("..\\really-outside"), "gpt-3.5-turbo-0613"
+        )
+        self.assertEqual(
+            sanitize_openai_model_id("a/b"), "gpt-3.5-turbo-0613"
+        )
+        self.assertEqual(sanitize_openai_model_id(""), "gpt-3.5-turbo-0613")
+        self.assertEqual(sanitize_openai_model_id(None), "gpt-3.5-turbo-0613")
+        self.assertEqual(sanitize_openai_model_id(12), "gpt-3.5-turbo-0613")
+        self.assertEqual(
+            sanitize_openai_model_id("bad model"), "gpt-3.5-turbo-0613"
+        )
+
+    def test_clamp(self):
+        self.assertEqual(clamp_chat_history_max_length(100), 100)
+        self.assertEqual(clamp_chat_history_max_length(0), 1)
+        self.assertEqual(clamp_chat_history_max_length(999999), 16000)
+        self.assertEqual(clamp_chat_history_max_length(True), 4000)
+        self.assertEqual(clamp_chat_history_max_length("nope"), 4000)
+        self.assertEqual(clamp_chat_history_max_length(float("nan")), 4000)
+
+    def test_filename(self):
+        self.assertEqual(
+            safe_chat_history_filename("2026-07-20-04-10-00"),
+            "chat_history_2026-07-20-04-10-00.json",
+        )
+        self.assertEqual(
+            safe_chat_history_filename("../x"), "chat_history_unknown.json"
+        )
+        self.assertEqual(
+            safe_chat_history_filename("a/b"), "chat_history_unknown.json"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fails closed on OpenAI model id charset/path tricks, clamps chat history max length, and keeps chat-history JSON filenames basename-only under `chat_history_path`.

## Changes
- New `llm_model.openai_model_params` helpers
- Wire `ChatGPTNode` model + history bounds + safe filename
- Offline unit tests

## Test plan
- [x] `PYTHONPATH=llm_model python3 -m unittest discover -s llm_model/test -p 'test_openai_model_params.py' -v`

AI-assisted; human-reviewed. Orthogonal to LLM function_call / robot / input open PRs.