### PR TITLE
fix(output): fail-closed when AWS credentials missing

### DIFF
--- a/llm_output/llm_output/aws_credentials.py
+++ b/llm_output/llm_output/aws_credentials.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""AWS credential validation helpers (pure, testable offline)."""
+
+
+def aws_credentials_ok(access_key_id, secret_access_key) -> bool:
+    """Return True only when both AWS IAM credentials are non-empty strings."""
+    if not isinstance(access_key_id, str) or not isinstance(secret_access_key, str):
+        return False
+    if not access_key_id.strip() or not secret_access_key.strip():
+        return False
+    return True

--- a/llm_output/llm_output/llm_audio_output.py
+++ b/llm_output/llm_output/llm_audio_output.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_output.aws_credentials import aws_credentials_ok
 
 config = UserConfig()
 
@@ -80,6 +81,13 @@ class AudioOutput(Node):
 
     def feedback_for_user_callback(self, msg):
         self.get_logger().info("Received text: '%s'" % msg.data)
+
+        if not aws_credentials_ok(self.aws_access_key_id, self.aws_secret_access_key):
+            self.get_logger().error(
+                "AWS credentials missing or empty; skip Polly synthesis (fail-closed)"
+            )
+            self.publish_string("output_error", self.llm_state_publisher)
+            return
 
         # Call AWS Polly service to synthesize speech
         polly_client = self.aws_session.client("polly")

--- a/llm_output/test/test_aws_credentials.py
+++ b/llm_output/test/test_aws_credentials.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_output.aws_credentials import aws_credentials_ok
+
+
+class TestAwsCredentials(unittest.TestCase):
+    def test_ok(self):
+        self.assertTrue(aws_credentials_ok("AKIA", "secret"))
+
+    def test_empty(self):
+        self.assertFalse(aws_credentials_ok("", "secret"))
+        self.assertFalse(aws_credentials_ok("AKIA", ""))
+        self.assertFalse(aws_credentials_ok("  ", "secret"))
+        self.assertFalse(aws_credentials_ok("AKIA", "   "))
+
+    def test_none_and_types(self):
+        self.assertFalse(aws_credentials_ok(None, "secret"))
+        self.assertFalse(aws_credentials_ok("AKIA", None))
+        self.assertFalse(aws_credentials_ok(123, "secret"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Polly synthesis used to proceed even when `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` were missing or blank (boto3 then fails noisily, or worse, with partial env). This PR adds a pure `aws_credentials_ok` helper and fails closed in the feedback callback: log + publish `output_error`, skip synthesis.

## Motivation
Embodied LLM stacks should not call paid cloud TTS without credentials. Matches the fail-closed style already used elsewhere in the series (OpenAI key, etc.).

## Changes
- `llm_output/llm_output/aws_credentials.py` — pure validator
- `llm_audio_output.py` — early return when invalid
- `llm_output/test/test_aws_credentials.py` — offline unit tests

## Verification
```bash
cd llm_output && PYTHONPATH=. python3 test/test_aws_credentials.py -v
# 3 tests OK
```

AI-assisted; human-reviewed.