### PR TITLE
fix(output): bound and reject empty LLM feedback text for TTS

### DIFF
--- a/llm_output/llm_output/feedback_text.py
+++ b/llm_output/llm_output/feedback_text.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Sanitize LLM feedback strings before TTS / String publish."""
+
+DEFAULT_MAX_CHARS = 3000
+
+
+def sanitize_feedback_text(text, max_chars=DEFAULT_MAX_CHARS):
+    """
+    Return a cleaned feedback string, or None if unusable.
+
+    - None / non-str → None (bool is rejected)
+    - strip whitespace; empty → None
+    - truncate to max_chars (must be positive int)
+    """
+    if text is None or isinstance(text, bool) or not isinstance(text, str):
+        return None
+    cleaned = text.strip()
+    if not cleaned:
+        return None
+    try:
+        limit = int(max_chars)
+    except (TypeError, ValueError):
+        limit = DEFAULT_MAX_CHARS
+    if limit <= 0:
+        limit = DEFAULT_MAX_CHARS
+    if len(cleaned) > limit:
+        cleaned = cleaned[:limit]
+    return cleaned

--- a/llm_output/llm_output/llm_audio_output.py
+++ b/llm_output/llm_output/llm_audio_output.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_output.feedback_text import sanitize_feedback_text
 
 config = UserConfig()
 
@@ -81,11 +82,19 @@ class AudioOutput(Node):
     def feedback_for_user_callback(self, msg):
         self.get_logger().info("Received text: '%s'" % msg.data)
 
+        feedback = sanitize_feedback_text(msg.data)
+        if feedback is None:
+            self.get_logger().error(
+                "Empty or invalid LLM feedback text; skip Polly synthesis"
+            )
+            self.publish_string("output_error", self.llm_state_publisher)
+            return
+
         # Call AWS Polly service to synthesize speech
         polly_client = self.aws_session.client("polly")
         self.get_logger().info("Polly client successfully initialized.")
         response = polly_client.synthesize_speech(
-            Text=msg.data, OutputFormat="mp3", VoiceId=config.aws_voice_id
+            Text=feedback, OutputFormat="mp3", VoiceId=config.aws_voice_id
         )
 
         # Save the audio output to a file

--- a/llm_output/test/test_feedback_text.py
+++ b/llm_output/test/test_feedback_text.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_output.feedback_text import sanitize_feedback_text, DEFAULT_MAX_CHARS
+
+
+class TestFeedbackText(unittest.TestCase):
+    def test_ok(self):
+        self.assertEqual(sanitize_feedback_text("  hello  "), "hello")
+
+    def test_empty(self):
+        self.assertIsNone(sanitize_feedback_text(""))
+        self.assertIsNone(sanitize_feedback_text("   "))
+        self.assertIsNone(sanitize_feedback_text(None))
+
+    def test_types(self):
+        self.assertIsNone(sanitize_feedback_text(True))
+        self.assertIsNone(sanitize_feedback_text(12))
+
+    def test_truncate(self):
+        long = "a" * 50
+        self.assertEqual(len(sanitize_feedback_text(long, max_chars=10)), 10)
+
+    def test_bad_limit_falls_back(self):
+        s = "x" * (DEFAULT_MAX_CHARS + 5)
+        out = sanitize_feedback_text(s, max_chars=0)
+        self.assertEqual(len(out), DEFAULT_MAX_CHARS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Raw LLM feedback strings were passed straight into AWS Polly. Empty whitespace, non-strings, or multi-thousand-character dumps should not reach TTS. Adds `sanitize_feedback_text` (strip / empty→None / truncate default 3000) and skips synthesis with `output_error` when invalid.

## Motivation
Fail-closed output path; avoid useless Polly calls and overly long Speech Synthesis requests.

## Changes
- `llm_output/llm_output/feedback_text.py`
- wire in `llm_audio_output.feedback_for_user_callback`
- offline tests `test_feedback_text.py`

## Verification
```bash
cd llm_output && PYTHONPATH=. python3 test/test_feedback_text.py -v
```

Path-orthogonal to credential helper PR (separate module). AI-assisted; human-reviewed.