### PR TITLE
fix(config): clamp OpenAI sampling and history length bounds

### DIFF
--- a/llm_config/llm_config/user_config.py
+++ b/llm_config/llm_config/user_config.py
@@ -41,6 +41,73 @@
 from .robot_behavior import RobotBehavior
 import os
 
+import math
+
+
+def _finite_float(value, default):
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if not math.isfinite(v):
+        return float(default)
+    return v
+
+
+def clamp_openai_temperature(value, default=1.0):
+    v = _finite_float(value, default)
+    return max(0.0, min(2.0, v))
+
+
+def clamp_openai_top_p(value, default=1.0):
+    v = _finite_float(value, default)
+    if v <= 0.0:
+        return float(default) if float(default) > 0 else 1.0
+    return min(1.0, v)
+
+
+def clamp_openai_n(value, default=1):
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return int(default)
+    if n < 1:
+        return 1
+    if n > 16:
+        return 16
+    return n
+
+
+def clamp_openai_max_tokens(value, default=4000):
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return int(default)
+    if n < 1:
+        return 1
+    if n > 128000:
+        return 128000
+    return n
+
+
+def clamp_openai_penalty(value, default=0.0):
+    v = _finite_float(value, default)
+    return max(-2.0, min(2.0, v))
+
+
+def clamp_chat_history_max_length(value, default=4000):
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return int(default)
+    if n < 1:
+        return 1
+    if n > 100000:
+        return 100000
+    return n
+
+
+
 
 class UserConfig:
     def __init__(self):
@@ -53,22 +120,22 @@ class UserConfig:
         # [optional]: Name of the organization under which the OpenAI API key is registered
         self.openai_organization = "Auromix"
         # [optional]: Controls the creativity of the AI’s responses. Higher values lead to more creative, but less coherent, responses
-        self.openai_temperature = 1
+        self.openai_temperature = clamp_openai_temperature(1)
         # [optional]: Probability distribution cutoff for generating responses
-        self.openai_top_p = 1
+        self.openai_top_p = clamp_openai_top_p(1)
         # [optional]: Number of responses to generate in batch
-        self.openai_n = 1
+        self.openai_n = clamp_openai_n(1)
         # [optional]: Whether to stream response results or not
         self.openai_stream = False
         # [optional]: String that if present in the AI's response, marks the end of the response
         self.openai_stop = "NULL"
         # [optional]: Maximum number of tokens allowed in the AI's respons
-        self.openai_max_tokens = 4000
+        self.openai_max_tokens = clamp_openai_max_tokens(4000)
         # self.openai_max_tokens= 16000
         # [optional]: Value that promotes the AI to generates responses with higher diversity
-        self.openai_frequency_penalty = 0
+        self.openai_frequency_penalty = clamp_openai_penalty(0)
         # [optional]: Value that promotes the AI to generates responses with more information at the text prompt
-        self.openai_presence_penalty = 0
+        self.openai_presence_penalty = clamp_openai_penalty(0)
 
         # IO related
         # [optional]: The prompt given to the AI, provided by the user
@@ -87,7 +154,7 @@ class UserConfig:
         self.chat_history_path = os.path.expanduser("~")
         # self.chat_history_path = os.path.dirname(os.path.abspath(__file__))
         # [optional]: The limit of the chat history length
-        self.chat_history_max_length = 4000
+        self.chat_history_max_length = clamp_chat_history_max_length(4000)
         # self.chat_history_max_length=16000
 
         # Robot behavior related

--- a/llm_config/test/test_openai_sampling_clamps.py
+++ b/llm_config/test/test_openai_sampling_clamps.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline tests for OpenAI sampling clamps in user_config."""
+import math
+import unittest
+import sys
+import os
+import types
+import importlib.util
+
+_PKG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_LLM_CFG = os.path.join(_PKG_DIR, "llm_config")
+
+pkg = types.ModuleType("llm_config")
+pkg.__path__ = [_LLM_CFG]
+sys.modules["llm_config"] = pkg
+rb_mod = types.ModuleType("llm_config.robot_behavior")
+
+class RobotBehavior:
+    robot_functions_list = []
+
+rb_mod.RobotBehavior = RobotBehavior
+sys.modules["llm_config.robot_behavior"] = rb_mod
+spec = importlib.util.spec_from_file_location(
+    "llm_config.user_config",
+    os.path.join(_LLM_CFG, "user_config.py"),
+    submodule_search_locations=[_LLM_CFG],
+)
+uc = importlib.util.module_from_spec(spec)
+sys.modules["llm_config.user_config"] = uc
+spec.loader.exec_module(uc)
+
+
+class TestOpenAISamplingClamps(unittest.TestCase):
+    def test_temperature(self):
+        self.assertEqual(uc.clamp_openai_temperature(1), 1.0)
+        self.assertEqual(uc.clamp_openai_temperature(-1), 0.0)
+        self.assertEqual(uc.clamp_openai_temperature(9), 2.0)
+        self.assertEqual(uc.clamp_openai_temperature(float("nan")), 1.0)
+        self.assertEqual(uc.clamp_openai_temperature("x"), 1.0)
+
+    def test_top_p(self):
+        self.assertEqual(uc.clamp_openai_top_p(0.5), 0.5)
+        self.assertEqual(uc.clamp_openai_top_p(0), 1.0)
+        self.assertEqual(uc.clamp_openai_top_p(2), 1.0)
+        self.assertTrue(math.isfinite(uc.clamp_openai_top_p(float("inf"))))
+
+    def test_n_and_tokens(self):
+        self.assertEqual(uc.clamp_openai_n(3), 3)
+        self.assertEqual(uc.clamp_openai_n(0), 1)
+        self.assertEqual(uc.clamp_openai_n(100), 16)
+        self.assertEqual(uc.clamp_openai_max_tokens(100), 100)
+        self.assertEqual(uc.clamp_openai_max_tokens(0), 1)
+        self.assertEqual(uc.clamp_openai_max_tokens(999999), 128000)
+
+    def test_penalties_and_history(self):
+        self.assertEqual(uc.clamp_openai_penalty(0), 0.0)
+        self.assertEqual(uc.clamp_openai_penalty(-5), -2.0)
+        self.assertEqual(uc.clamp_openai_penalty(5), 2.0)
+        self.assertEqual(uc.clamp_chat_history_max_length(10), 10)
+        self.assertEqual(uc.clamp_chat_history_max_length(0), 1)
+        self.assertEqual(uc.clamp_chat_history_max_length(10**9), 100000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Clamp OpenAI sampling knobs and chat history max length in `UserConfig` so non-finite or extreme values cannot propagate if those fields are wired into `ChatCompletion.create`.

## Changes
- `clamp_openai_temperature` → [0, 2]
- `clamp_openai_top_p` → (0, 1]
- `clamp_openai_n` → 1..16
- `clamp_openai_max_tokens` → 1..128000
- `clamp_openai_penalty` → [-2, 2]
- `clamp_chat_history_max_length` → 1..100000
- Offline unit tests

## Motivation
Config currently stores sampling parameters that are commented at the call site but still part of the public UserConfig surface. Fail-closed clamps protect demos and future enablement without changing default happy-path numbers.

## Verification
```bash
python3 llm_config/test/test_openai_sampling_clamps.py -v
```

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
