### PR TITLE
fix(input): sanitize AWS region and S3 bucket names

### DIFF
--- a/llm_input/llm_input/aws_s3_params.py
+++ b/llm_input/llm_input/aws_s3_params.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (AWS region + S3 bucket sanitize)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed sanitizers for AWS region ids and S3 bucket names (pure/offline).
+
+"""Sanitize AWS region and S3 bucket names before boto3/S3 URI construction."""
+
+from __future__ import annotations
+
+import re
+
+# Standard AWS region shape: us-east-1, ap-southeast-1, eu-central-1, etc.
+_REGION_RE = re.compile(r"^[a-z]{2}(?:-[a-z]+)+-\d+$")
+
+# DNS-style S3 bucket subset (AWS rules tightened for safety).
+_BUCKET_RE = re.compile(r"^[a-z0-9][a-z0-9.\-]{1,61}[a-z0-9]$")
+
+
+def sanitize_aws_region(raw):
+    """
+    Return a normalized AWS region id, or None if invalid.
+
+    Accepts lowercase region strings matching the common AWS pattern
+    (e.g. ``us-east-1``, ``ap-southeast-1``). Rejects None/bool/non-str,
+    empty/whitespace, path fragments, and non-region garbage.
+    """
+    if raw is None or isinstance(raw, bool) or not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if ".." in text or "/" in text or "\\" in text or " " in text:
+        return None
+    if any(ord(ch) < 32 for ch in text):
+        return None
+    # Force lowercase compare; reject mixed case by requiring exact lower
+    if text != text.lower():
+        return None
+    if not _REGION_RE.match(text):
+        return None
+    # Bound length (AWS regions are short)
+    if len(text) > 32:
+        return None
+    return text
+
+
+def sanitize_s3_bucket_name(raw):
+    """
+    Return a safe S3 bucket name, or None if invalid.
+
+    Applies a strict DNS-compatible subset of AWS bucket naming:
+    3–63 chars, lowercase letters/digits/hyphen/dot, start/end alnum,
+    no adjacent periods, no ``.-`` / ``-.`` pairs, no IP-looking 4-octet forms.
+    """
+    if raw is None or isinstance(raw, bool) or not isinstance(raw, str):
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    if ".." in text or "/" in text or "\\" in text or " " in text:
+        return None
+    if any(ord(ch) < 32 for ch in text):
+        return None
+    if text != text.lower():
+        return None
+    if len(text) < 3 or len(text) > 63:
+        return None
+    if not _BUCKET_RE.match(text):
+        return None
+    if ".-" in text or "-." in text:
+        return None
+    # Reject IPv4-shaped names (AWS disallows)
+    if re.match(r"^\d{1,3}(?:\.\d{1,3}){3}$", text):
+        return None
+    return text

--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.aws_s3_params import sanitize_aws_region, sanitize_s3_bucket_name
 
 config = UserConfig()
 
@@ -57,12 +58,19 @@ class AudioInput(Node):
         self.aws_audio_file = "/tmp/user_audio_input.flac"
         self.aws_access_key_id = config.aws_access_key_id
         self.aws_secret_access_key = config.aws_secret_access_key
-        self.aws_region_name = config.aws_region_name
-        self.aws_session = boto3.Session(
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
-            region_name=self.aws_region_name,
-        )
+        # Fail-closed: only keep a validated AWS region for the session.
+        self.aws_region_name = sanitize_aws_region(config.aws_region_name)
+        self.aws_session = None
+        if self.aws_region_name is not None:
+            self.aws_session = boto3.Session(
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                region_name=self.aws_region_name,
+            )
+        else:
+            self.get_logger().error(
+                "Invalid AWS region_name; S3/Transcribe input disabled (fail-closed)"
+            )
 
         # Initialization publisher
         self.initialization_publisher = self.create_publisher(
@@ -89,12 +97,26 @@ class AudioInput(Node):
             self.action_function_listening()
 
     def action_function_listening(self):
+        # Fail-closed config gate before allocating buffers / talking to AWS.
+        if self.aws_session is None or self.aws_region_name is None:
+            self.get_logger().error(
+                "AWS region invalid or session missing; skip recording (fail-closed)"
+            )
+            self.publish_string("input_error", self.llm_state_publisher)
+            return
+        bucket_name = sanitize_s3_bucket_name(config.bucket_name)
+        if bucket_name is None:
+            self.get_logger().error(
+                "Invalid S3 bucket_name; skip recording/upload (fail-closed)"
+            )
+            self.publish_string("input_error", self.llm_state_publisher)
+            return
+
         # Recording settings
         duration = config.duration  # Audio recording duration, in seconds
         sample_rate = config.sample_rate  # Sample rate
         volume_gain_multiplier = config.volume_gain_multiplier  # Volume gain multiplier
         # AWS S3 settings
-        bucket_name = config.bucket_name
         audio_file_key = "gpt_audio.flac"  # Name of the audio file in S3
         transcribe_job_name = (
             f'my-transcribe-job-{datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")}'

--- a/llm_input/test/test_aws_s3_params.py
+++ b/llm_input/test/test_aws_s3_params.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_input.aws_s3_params import sanitize_aws_region, sanitize_s3_bucket_name
+
+
+class TestAwsS3Params(unittest.TestCase):
+    def test_region_ok(self):
+        self.assertEqual(sanitize_aws_region("ap-southeast-1"), "ap-southeast-1")
+        self.assertEqual(sanitize_aws_region("us-east-1"), "us-east-1")
+        self.assertEqual(sanitize_aws_region("eu-west-1"), "eu-west-1")
+        self.assertEqual(sanitize_aws_region("  us-west-2  "), "us-west-2")
+
+    def test_region_reject(self):
+        self.assertIsNone(sanitize_aws_region(None))
+        self.assertIsNone(sanitize_aws_region(True))
+        self.assertIsNone(sanitize_aws_region(12))
+        self.assertIsNone(sanitize_aws_region(""))
+        self.assertIsNone(sanitize_aws_region("   "))
+        self.assertIsNone(sanitize_aws_region("../x"))
+        self.assertIsNone(sanitize_aws_region("s3://evil"))
+        self.assertIsNone(sanitize_aws_region("US-EAST-1"))
+        self.assertIsNone(sanitize_aws_region("us east 1"))
+        self.assertIsNone(sanitize_aws_region("not-a-region"))
+        self.assertIsNone(sanitize_aws_region("us"))
+
+    def test_bucket_ok(self):
+        self.assertEqual(sanitize_s3_bucket_name("auromixbucket"), "auromixbucket")
+        self.assertEqual(sanitize_s3_bucket_name("my.bucket-name"), "my.bucket-name")
+        self.assertEqual(sanitize_s3_bucket_name("  abc  "), "abc")
+
+    def test_bucket_reject(self):
+        self.assertIsNone(sanitize_s3_bucket_name(None))
+        self.assertIsNone(sanitize_s3_bucket_name(True))
+        self.assertIsNone(sanitize_s3_bucket_name(""))
+        self.assertIsNone(sanitize_s3_bucket_name("ab"))  # too short
+        self.assertIsNone(sanitize_s3_bucket_name("My_Bucket"))
+        self.assertIsNone(sanitize_s3_bucket_name("a..b"))
+        self.assertIsNone(sanitize_s3_bucket_name("../x"))
+        self.assertIsNone(sanitize_s3_bucket_name("bad_name_underscore"))
+        self.assertIsNone(sanitize_s3_bucket_name("bucket.-bad"))
+        self.assertIsNone(sanitize_s3_bucket_name("192.168.1.1"))
+        self.assertIsNone(sanitize_s3_bucket_name("-leading"))
+        self.assertIsNone(sanitize_s3_bucket_name("trailing-"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fail-closed sanitize of AWS region id and S3 bucket name before boto3 session / S3 URI construction in the audio input node.
- Invalid config logs and returns `input_error` instead of uploading to a mangled path.

## Motivation

`aws_region_name` and `bucket_name` were taken raw from config. Malformed values (path fragments, mixed case, underscored buckets, short names) can produce bad Transcribe/S3 targets. Bound them with offline-tested pure helpers.

## Verification

- `PYTHONPATH=llm_input python3 -m unittest discover -s llm_input/test -p 'test_aws_s3_params.py' -v` — 4 passed
- Did NOT change: Polly output, Whisper, language whitelists, robot cmd_vel

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
