### PR TITLE
fix(input): fail-closed when AWS credentials missing

### DIFF
--- a/llm_input/llm_input/aws_credentials.py
+++ b/llm_input/llm_input/aws_credentials.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (AWS credential fail-closed, input)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS credential validation helpers for audio input (pure, testable offline)."""
+
+
+def aws_credentials_ok(access_key_id, secret_access_key) -> bool:
+    """Return True only when both AWS IAM credentials are non-empty strings."""
+    if not isinstance(access_key_id, str) or not isinstance(secret_access_key, str):
+        return False
+    if not access_key_id.strip() or not secret_access_key.strip():
+        return False
+    return True

--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.aws_credentials import aws_credentials_ok
 
 config = UserConfig()
 
@@ -58,11 +59,17 @@ class AudioInput(Node):
         self.aws_access_key_id = config.aws_access_key_id
         self.aws_secret_access_key = config.aws_secret_access_key
         self.aws_region_name = config.aws_region_name
-        self.aws_session = boto3.Session(
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
-            region_name=self.aws_region_name,
-        )
+        self.aws_session = None
+        if aws_credentials_ok(self.aws_access_key_id, self.aws_secret_access_key):
+            self.aws_session = boto3.Session(
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                region_name=self.aws_region_name,
+            )
+        else:
+            self.get_logger().error(
+                "AWS credentials missing or empty; S3/Transcribe input disabled (fail-closed)"
+            )
 
         # Initialization publisher
         self.initialization_publisher = self.create_publisher(
@@ -89,6 +96,16 @@ class AudioInput(Node):
             self.action_function_listening()
 
     def action_function_listening(self):
+        # Fail-closed: never record/upload without usable IAM credentials.
+        if self.aws_session is None or not aws_credentials_ok(
+            self.aws_access_key_id, self.aws_secret_access_key
+        ):
+            self.get_logger().error(
+                "AWS credentials missing or empty; skip recording (fail-closed)"
+            )
+            self.publish_string("input_error", self.llm_state_publisher)
+            return
+
         # Recording settings
         duration = config.duration  # Audio recording duration, in seconds
         sample_rate = config.sample_rate  # Sample rate

--- a/llm_input/test/test_aws_credentials.py
+++ b/llm_input/test/test_aws_credentials.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_input.aws_credentials import aws_credentials_ok
+
+
+class TestAwsCredentialsInput(unittest.TestCase):
+    def test_ok(self):
+        self.assertTrue(aws_credentials_ok("AKIAEXAMPLE", "secret"))
+
+    def test_empty(self):
+        self.assertFalse(aws_credentials_ok("", "secret"))
+        self.assertFalse(aws_credentials_ok("AKIAEXAMPLE", ""))
+        self.assertFalse(aws_credentials_ok("  ", "secret"))
+        self.assertFalse(aws_credentials_ok("AKIAEXAMPLE", "   "))
+
+    def test_none_and_types(self):
+        self.assertFalse(aws_credentials_ok(None, "secret"))
+        self.assertFalse(aws_credentials_ok("AKIAEXAMPLE", None))
+        self.assertFalse(aws_credentials_ok(123, "secret"))
+        self.assertFalse(aws_credentials_ok("AKIAEXAMPLE", True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fail-closed AWS IAM credential check on the **audio input** path before boto3 session / S3 upload / Transcribe.
- Symmetric to output Polly guard (#32); missing keys log and publish `input_error` instead of calling AWS.

## Motivation

`llm_audio_input` built a boto3 session from possibly-None env keys with no gate. Empty credentials still attempt record + S3 upload and fail late. Guard early offline with a pure helper.

## Verification

- `PYTHONPATH=llm_input python3 -m unittest discover -s llm_input/test -p 'test_aws_credentials.py' -v` — 3 passed
- Did NOT change: region/bucket (#34), sampling clamps (#35), Polly output (#32)

## Differential value

Related open work is config region/bucket (#34) and output credentials (#32). This PR only covers **input-path IAM key presence**.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
