### PR TITLE
fix(model): coerce None OpenAI content before String publish

### DIFF
--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,6 +46,7 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.text_content import normalize_openai_text
 
 
 # Global Initialization
@@ -127,7 +128,7 @@ class ChatGPTNode(Node):
 
     def publish_string(self, string_to_send, publisher_to_use):
         msg = String()
-        msg.data = string_to_send
+        msg.data = normalize_openai_text(string_to_send)
 
         publisher_to_use.publish(msg)
         self.get_logger().info(
@@ -204,7 +205,8 @@ class ChatGPTNode(Node):
         """
         # Getting response information
         message = chatgpt_response["choices"][0]["message"]
-        content = message.get("content")
+        content = normalize_openai_text(message.get("content"))
+        # Empty content means function-call style responses (flag below)
         function_call = message.get("function_call", None)
 
         # Initializing function flag, 0: no function call, 1: function call
@@ -212,12 +214,18 @@ class ChatGPTNode(Node):
 
         # If the content is not None, then the response is text
         # If the content is None, then the response is function call
-        if content is not None:
+        if content != "" and function_call is None:
+            function_flag = 0
+            self.get_logger().info("OpenAI response type: TEXT")
+        elif function_call is not None:
+            function_flag = 1
+            self.get_logger().info("OpenAI response type: FUNCTION CALL")
+        elif content != "":
             function_flag = 0
             self.get_logger().info("OpenAI response type: TEXT")
         else:
-            function_flag = 1
-            self.get_logger().info("OpenAI response type: FUNCTION CALL")
+            function_flag = 0
+            self.get_logger().info("OpenAI response type: TEXT")
         # Log
         self.get_logger().info(
             f"Get message from OpenAI: {message}, type: {type(message)}"

--- a/llm_model/llm_model/text_content.py
+++ b/llm_model/llm_model/text_content.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2023 Herman Ye @Auromix
+# Licensed under the Apache License, Version 2.0
+#
+# Helpers to normalize OpenAI message content for ROS std_msgs/String publish.
+
+
+def normalize_openai_text(content):
+    """Return a string safe for std_msgs/msg/String.data.
+
+    OpenAI function-call responses often set content to None. Assigning None
+    to String.data raises; publishing empty string is the safe no-op path.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, bytes):
+        return content.decode("utf-8", errors="replace")
+    if isinstance(content, str):
+        return content
+    return str(content)

--- a/llm_model/test/test_normalize_openai_text.py
+++ b/llm_model/test/test_normalize_openai_text.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+import sys
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parents[1] / "llm_model"
+sys.path.insert(0, str(PKG))
+
+from text_content import normalize_openai_text  # noqa: E402
+
+
+class TestNormalizeOpenAIText(unittest.TestCase):
+    def test_none(self):
+        self.assertEqual(normalize_openai_text(None), "")
+
+    def test_str_passthrough(self):
+        self.assertEqual(normalize_openai_text("hello"), "hello")
+
+    def test_empty_str(self):
+        self.assertEqual(normalize_openai_text(""), "")
+
+    def test_bytes(self):
+        self.assertEqual(normalize_openai_text(b"hi"), "hi")
+
+    def test_int(self):
+        self.assertEqual(normalize_openai_text(42), "42")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
OpenAI function-call responses often set `message.content` to `None`. Feeding that into `std_msgs/msg/String.data` (or logging paths that assume a string) is unsafe.

This change:
- Adds `normalize_openai_text()` pure helper
- Coerces content at the response boundary
- Hardens `publish_string` so publishers never receive `None`
- Keeps function-call detection based on a non-`None` `function_call` field

## Motivation
Defensive fix for a real crash path when the model chooses a tool/function call over plain text feedback.

## Verification
```
python3 llm_model/test/test_normalize_openai_text.py -v
# 5 tests OK offline
```

AI-assisted scope; human-reviewed before open.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->