### PR TITLE
fix(model): ensure chat history directory exists before write

### DIFF
--- a/llm_model/llm_model/chat_history_path.py
+++ b/llm_model/llm_model/chat_history_path.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2023 Herman Ye @Auromix
+# Licensed under the Apache License, Version 2.0
+#
+# Normalize and ensure the chat history directory used by ChatGPTNode.
+
+import os
+
+
+def normalize_chat_history_dir(path):
+    """Return an absolute directory path for chat history JSON files.
+
+    Empty/None input falls back to the user home directory.
+    """
+    if path is None:
+        raw = ""
+    else:
+        raw = str(path).strip()
+    if not raw:
+        raw = "~"
+    return os.path.abspath(os.path.expanduser(raw))
+
+
+def ensure_chat_history_dir(path):
+    """Normalize ``path`` and create the directory if needed. Return abs path."""
+    directory = normalize_chat_history_dir(path)
+    os.makedirs(directory, exist_ok=True)
+    return directory

--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,6 +46,7 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.chat_history_path import ensure_chat_history_dir
 
 
 # Global Initialization
@@ -110,8 +111,9 @@ class ChatGPTNode(Node):
         # TODO: Longer interactive content should be stored in the JSON file
         # exceeding token limit, waiting to update @Herman Ye
         self.start_timestamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
+        history_dir = ensure_chat_history_dir(config.chat_history_path)
         self.chat_history_file = os.path.join(
-            config.chat_history_path, f"chat_history_{self.start_timestamp}.json"
+            history_dir, f"chat_history_{self.start_timestamp}.json"
         )
         self.write_chat_history_to_json()
         self.get_logger().info(f"Chat history saved to {self.chat_history_file}")

--- a/llm_model/test/test_chat_history_path.py
+++ b/llm_model/test/test_chat_history_path.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import os
+import tempfile
+import unittest
+import sys
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parents[1] / "llm_model"
+sys.path.insert(0, str(PKG))
+
+from chat_history_path import (  # noqa: E402
+    ensure_chat_history_dir,
+    normalize_chat_history_dir,
+)
+
+
+class TestChatHistoryPath(unittest.TestCase):
+    def test_empty_falls_back_home(self):
+        got = normalize_chat_history_dir("")
+        self.assertTrue(os.path.isabs(got))
+        self.assertEqual(got, os.path.abspath(os.path.expanduser("~")))
+
+    def test_none_falls_back_home(self):
+        got = normalize_chat_history_dir(None)
+        self.assertEqual(got, os.path.abspath(os.path.expanduser("~")))
+
+    def test_expanduser(self):
+        got = normalize_chat_history_dir("~/llm_chat_hist_test_norm")
+        self.assertTrue(got.endswith("llm_chat_hist_test_norm"))
+        self.assertTrue(os.path.isabs(got))
+
+    def test_ensure_makedirs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = os.path.join(tmp, "nested", "hist")
+            out = ensure_chat_history_dir(target)
+            self.assertTrue(os.path.isdir(out))
+            self.assertEqual(out, os.path.abspath(target))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
`ChatGPTNode` writes `chat_history_<timestamp>.json` under `UserConfig.chat_history_path` without ensuring that directory exists or is absolute. A missing path causes startup IO failures.

## Changes
- `normalize_chat_history_dir` / `ensure_chat_history_dir` pure helpers
- Call ensure before the first history write in node init
- Empty/None path falls back to user home
- Offline unit tests (tmpdir + home fallback)

## Verification
```
python3 llm_model/test/test_chat_history_path.py -v
# 4 tests OK offline
```

AI-assisted scope; human-reviewed before open.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->