### PR TITLE
fix(model): allowlist chat history message roles

### DIFF
--- a/llm_model/llm_model/chat_role_sanitize.py
+++ b/llm_model/llm_model/chat_role_sanitize.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (chat role allowlist)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed allowlist for OpenAI chat history message roles.
+
+"""Allowlist chat-history message roles before append / OpenAI replay."""
+
+from __future__ import annotations
+
+ALLOWED_CHAT_ROLES = frozenset(
+    {
+        "system",
+        "user",
+        "assistant",
+        "function",
+        "tool",
+    }
+)
+
+
+def sanitize_chat_role(role):
+    """
+    Return a normalized role string, or None if not allowlisted.
+
+    - None / bool / non-str → None
+    - strip + casefold to lower
+    - empty → None
+    - must be in ALLOWED_CHAT_ROLES
+    """
+    if role is None or isinstance(role, bool) or not isinstance(role, str):
+        return None
+    cleaned = role.strip().lower()
+    if not cleaned:
+        return None
+    if cleaned not in ALLOWED_CHAT_ROLES:
+        return None
+    return cleaned

--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,6 +46,7 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.chat_role_sanitize import sanitize_chat_role
 
 
 # Global Initialization
@@ -146,9 +147,16 @@ class ChatGPTNode(Node):
         the oldest message_element_object will be removed.
         Returns the updated chat history list.
         """
+        # Fail-closed: only OpenAI-valid roles may enter history.
+        clean_role = sanitize_chat_role(role)
+        if clean_role is None:
+            self.get_logger().error(
+                f"Rejected invalid chat history role: {role!r}"
+            )
+            return config.chat_history
         # Creating message dictionary with given options
         message_element_object = {
-            "role": role,
+            "role": clean_role,
             "content": content,
         }
         # Adding function call information if provided

--- a/llm_model/test/test_chat_role_sanitize.py
+++ b/llm_model/test/test_chat_role_sanitize.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2026 Bartok / contributors
+# Licensed under the Apache License, Version 2.0
+
+import unittest
+
+from llm_model.chat_role_sanitize import ALLOWED_CHAT_ROLES, sanitize_chat_role
+
+
+class TestChatRoleSanitize(unittest.TestCase):
+    def test_ok(self):
+        for role in sorted(ALLOWED_CHAT_ROLES):
+            self.assertEqual(sanitize_chat_role(role), role)
+        self.assertEqual(sanitize_chat_role(" User "), "user")
+        self.assertEqual(sanitize_chat_role("ASSISTANT"), "assistant")
+
+    def test_reject(self):
+        self.assertIsNone(sanitize_chat_role("root"))
+        self.assertIsNone(sanitize_chat_role("admin"))
+        self.assertIsNone(sanitize_chat_role(""))
+        self.assertIsNone(sanitize_chat_role("   "))
+        self.assertIsNone(sanitize_chat_role(None))
+        self.assertIsNone(sanitize_chat_role(True))
+        self.assertIsNone(sanitize_chat_role(12))
+        self.assertIsNone(sanitize_chat_role("user;drop"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Allowlist OpenAI chat history roles (`system`/`user`/`assistant`/`function`/`tool`) before append.
- Fail-closed: invalid roles are rejected and history is left unchanged.

## Motivation

`add_message_to_history` previously stuffed any role string into history. A poisoned or buggy caller could inject non-OpenAI roles into subsequent ChatCompletion calls.

## Differential note

Concurrent #40 (Claim: bartok) covers history *directory* ensure/mkdir. This PR is orthogonal (roles only). Left #40 alone.

## Changes

- New `llm_model/llm_model/chat_role_sanitize.py`
- Thin wire in `ChatGPTNode.add_message_to_history`
- Offline tests: `llm_model/test/test_chat_role_sanitize.py`

## Verification

- `PYTHONPATH=llm_model python3 -m unittest discover -s llm_model/test -p 'test_chat_role_sanitize.py' -v` — 2 passed (8 asserts)

## Notes

AI-assisted; human-reviewed. Pivot from abandoned home-confinement plan after concurrent #40.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
