### PR TITLE
fix(input): bound transcript text before ROS publish

### DIFF
--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.transcript_sanitize import sanitize_transcript_text
 
 config = UserConfig()
 
@@ -158,12 +159,13 @@ class AudioInput(Node):
             transcript_data = json.loads(response.text)
             transcript_text = transcript_data["results"]["transcripts"][0]["transcript"]
             self.get_logger().info("Audio to text conversion complete!")
-            # Step 8: Publish the transcribed text to ROS2
-            if transcript_text == "":  # Empty input
-                self.get_logger().info("Empty input!")
+            # Step 8: Publish the transcribed text to ROS2 (bounded / fail-closed)
+            cleaned = sanitize_transcript_text(transcript_text)
+            if cleaned is None:
+                self.get_logger().info("Empty or invalid transcript; re-listen")
                 self.publish_string("listening", self.llm_state_publisher)
             else:
-                self.publish_string(transcript_text, self.audio_to_text_publisher)
+                self.publish_string(cleaned, self.audio_to_text_publisher)
             # Step 9: Delete the temporary audio file from AWS S3
             s3.delete_object(Bucket=bucket_name, Key=audio_file_key)
 

--- a/llm_input/llm_input/llm_audio_input_local.py
+++ b/llm_input/llm_input/llm_audio_input_local.py
@@ -40,6 +40,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.transcript_sanitize import sanitize_transcript_text
 
 config = UserConfig()
 
@@ -109,12 +110,13 @@ class AudioInput(Node):
         transcript_text = whisper_result["text"]
         self.get_logger().info("Audio to text conversion complete!")
 
-        # Step 8: Publish the transcribed text to ROS2
-        if transcript_text == "":  # Empty input
-            self.get_logger().info("Empty input!")
+        # Step 8: Publish the transcribed text to ROS2 (bounded / fail-closed)
+        cleaned = sanitize_transcript_text(transcript_text)
+        if cleaned is None:
+            self.get_logger().info("Empty or invalid transcript; re-listen")
             self.publish_string("listening", self.llm_state_publisher)
         else:
-            self.publish_string(transcript_text, self.audio_to_text_publisher)
+            self.publish_string(cleaned, self.audio_to_text_publisher)
 
     def publish_string(self, string_to_send, publisher_to_use):
         msg = String()

--- a/llm_input/llm_input/transcript_sanitize.py
+++ b/llm_input/llm_input/transcript_sanitize.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Bartok / contributors (transcript bounds)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-closed sanitizer for ASR/Whisper transcripts before ROS publish.
+
+"""Sanitize transcript text before publishing to /llm_input_audio_to_text."""
+
+from __future__ import annotations
+
+DEFAULT_MAX_CHARS = 4000
+
+
+def sanitize_transcript_text(text, max_chars=DEFAULT_MAX_CHARS):
+    """
+    Return a cleaned transcript string, or None if unusable.
+
+    - None / bool / non-str → None
+    - strip ends; empty → None
+    - drop C0 controls except newline and tab; empty after → None
+    - truncate to max_chars (positive int; bad max → default)
+    """
+    if text is None or isinstance(text, bool) or not isinstance(text, str):
+        return None
+
+    cleaned_chars = []
+    for ch in text:
+        code = ord(ch)
+        if code < 32 and ch not in ("\n", "\t"):
+            continue
+        cleaned_chars.append(ch)
+    cleaned = "".join(cleaned_chars).strip()
+    if not cleaned:
+        return None
+
+    try:
+        limit = int(max_chars)
+    except (TypeError, ValueError):
+        limit = DEFAULT_MAX_CHARS
+    if isinstance(max_chars, bool) or limit <= 0:
+        limit = DEFAULT_MAX_CHARS
+
+    if len(cleaned) > limit:
+        cleaned = cleaned[:limit]
+    return cleaned

--- a/llm_input/test/test_transcript_sanitize.py
+++ b/llm_input/test/test_transcript_sanitize.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2026 Bartok / contributors
+# Licensed under the Apache License, Version 2.0
+
+import unittest
+
+from llm_input.transcript_sanitize import (
+    DEFAULT_MAX_CHARS,
+    sanitize_transcript_text,
+)
+
+
+class TestTranscriptSanitize(unittest.TestCase):
+    def test_ok(self):
+        self.assertEqual(sanitize_transcript_text("Hello"), "Hello")
+        self.assertEqual(sanitize_transcript_text("  hi  "), "hi")
+        self.assertEqual(sanitize_transcript_text("a\nb\tc"), "a\nb\tc")
+
+    def test_empty(self):
+        self.assertIsNone(sanitize_transcript_text(""))
+        self.assertIsNone(sanitize_transcript_text("   "))
+        self.assertIsNone(sanitize_transcript_text(None))
+
+    def test_types(self):
+        self.assertIsNone(sanitize_transcript_text(True))
+        self.assertIsNone(sanitize_transcript_text(False))
+        self.assertIsNone(sanitize_transcript_text(12))
+
+    def test_controls(self):
+        self.assertIsNone(sanitize_transcript_text("\x00\x01\x02"))
+        self.assertEqual(sanitize_transcript_text("a\x00b"), "ab")
+
+    def test_truncate(self):
+        long = "a" * 5000
+        out = sanitize_transcript_text(long)
+        self.assertEqual(len(out), DEFAULT_MAX_CHARS)
+        self.assertEqual(len(sanitize_transcript_text(long, max_chars=10)), 10)
+
+    def test_bad_limit_falls_back(self):
+        s = "x" * (DEFAULT_MAX_CHARS + 5)
+        out = sanitize_transcript_text(s, max_chars=0)
+        self.assertEqual(len(out), DEFAULT_MAX_CHARS)
+        out2 = sanitize_transcript_text(s, max_chars=True)
+        self.assertEqual(len(out2), DEFAULT_MAX_CHARS)
+        out3 = sanitize_transcript_text(s, max_chars="nope")
+        self.assertEqual(len(out3), DEFAULT_MAX_CHARS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Bound and sanitize ASR/Whisper transcript text before publishing to `/llm_input_audio_to_text`.
- Applies to both AWS Transcribe input node and local Whisper input node.

## Motivation

Both input nodes only rejected the empty string. Oversized or control-laden transcripts could flood the model topic and chat history ahead of open #37 (user prompt bounds). Fail-closed re-listen when the transcript is unusable after sanitize.

## Changes

- New `llm_input/llm_input/transcript_sanitize.py` → `sanitize_transcript_text`
- Thin wire in `llm_audio_input.py` and `llm_audio_input_local.py`
- Offline tests: `llm_input/test/test_transcript_sanitize.py`

## Verification

- `PYTHONPATH=llm_input python3 -m unittest discover -s llm_input/test -p 'test_transcript_sanitize.py' -v` — 6 passed
- Orthogonal helper to open #26/#29/#30/#38 input path set

## Notes

AI-assisted; human-reviewed. Defense-in-depth vs model-side prompt bounds.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
