### PR TITLE
fix(robot): fail-closed JSON parse for ChatGPT function_call service

### DIFF
--- a/llm_robot/llm_robot/arx5_arm_robot.py
+++ b/llm_robot/llm_robot/arx5_arm_robot.py
@@ -41,6 +41,7 @@ from std_srvs.srv import Empty
 import json
 import os
 from llm_config.user_config import UserConfig
+from llm_robot.function_call_json import parse_function_call_request
 
 # Global Initialization
 config = UserConfig()
@@ -63,10 +64,19 @@ class ArmRobot(Node):
         self.get_logger().info("ArmRobot node has been initialized")
 
     def function_call_callback(self, request, response):
-        req = json.loads(request.request_text)
-        function_name = req["name"]
-        function_args = json.loads(req["arguments"])
-        func_obj = getattr(self, function_name)
+        ok, function_name, function_args, parse_error = parse_function_call_request(
+            request.request_text
+        )
+        if not ok:
+            self.get_logger().info(f"Failed to parse function call: {parse_error}")
+            response.response_text = str(parse_error)
+            return response
+        func_obj = getattr(self, function_name, None)
+        if not callable(func_obj):
+            err = f"unknown function: {function_name}"
+            self.get_logger().info(f"Failed to call function: {err}")
+            response.response_text = err
+            return response
         try:
             function_execution_result = func_obj(**function_args)
         except Exception as error:

--- a/llm_robot/llm_robot/function_call_json.py
+++ b/llm_robot/llm_robot/function_call_json.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Fail-closed JSON parsing for ChatGPT function_call service requests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional, Tuple
+
+
+def parse_function_call_request(
+    request_text: Any,
+) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]], Optional[str]]:
+    """Parse LLM function-call JSON into (ok, name, args, error)."""
+    if request_text is None:
+        return False, None, None, "request_text is empty"
+    if isinstance(request_text, bytes):
+        try:
+            request_text = request_text.decode("utf-8")
+        except Exception as exc:  # noqa: BLE001
+            return False, None, None, f"request_text decode failed: {exc}"
+    if not isinstance(request_text, str):
+        request_text = str(request_text)
+    text = request_text.strip()
+    if not text:
+        return False, None, None, "request_text is empty"
+
+    try:
+        req = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return False, None, None, f"invalid JSON: {exc}"
+
+    if not isinstance(req, dict):
+        return False, None, None, "request JSON must be an object"
+
+    name = req.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return False, None, None, "missing or invalid function name"
+    name = name.strip()
+
+    raw_args = req.get("arguments", {})
+    if isinstance(raw_args, str):
+        raw_args = raw_args.strip()
+        if not raw_args:
+            args: Dict[str, Any] = {}
+        else:
+            try:
+                args = json.loads(raw_args)
+            except json.JSONDecodeError as exc:
+                return False, None, None, f"invalid arguments JSON: {exc}"
+    elif isinstance(raw_args, dict):
+        args = raw_args
+    elif raw_args is None:
+        args = {}
+    else:
+        return False, None, None, "arguments must be object or JSON string"
+
+    if not isinstance(args, dict):
+        return False, None, None, "arguments must decode to an object"
+
+    return True, name, args, None

--- a/llm_robot/llm_robot/multi_robot.py
+++ b/llm_robot/llm_robot/multi_robot.py
@@ -33,6 +33,7 @@ from llm_interfaces.srv import ChatGPT
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_robot.function_call_json import parse_function_call_request
 
 config = UserConfig()
 
@@ -80,10 +81,19 @@ class MultiRobot(Node):
         self.publish_string("robot", self.initialization_publisher)
 
     def function_call_callback(self, request, response):
-        req = json.loads(request.request_text)
-        function_name = req["name"]
-        function_args = json.loads(req["arguments"])
-        func_obj = getattr(self, function_name)
+        ok, function_name, function_args, parse_error = parse_function_call_request(
+            request.request_text
+        )
+        if not ok:
+            self.get_logger().info(f"Failed to parse function call: {parse_error}")
+            response.response_text = str(parse_error)
+            return response
+        func_obj = getattr(self, function_name, None)
+        if not callable(func_obj):
+            err = f"unknown function: {function_name}"
+            self.get_logger().info(f"Failed to call function: {err}")
+            response.response_text = err
+            return response
         try:
             function_execution_result = func_obj(**function_args)
         except Exception as error:

--- a/llm_robot/llm_robot/turtle_robot.py
+++ b/llm_robot/llm_robot/turtle_robot.py
@@ -40,6 +40,7 @@ from std_srvs.srv import Empty
 # LLM related
 import json
 from llm_config.user_config import UserConfig
+from llm_robot.function_call_json import parse_function_call_request
 
 # Global Initialization
 config = UserConfig()
@@ -63,10 +64,19 @@ class TurtleRobot(Node):
         self.get_logger().info("TurtleRobot node has been initialized")
 
     def function_call_callback(self, request, response):
-        req = json.loads(request.request_text)
-        function_name = req["name"]
-        function_args = json.loads(req["arguments"])
-        func_obj = getattr(self, function_name)
+        ok, function_name, function_args, parse_error = parse_function_call_request(
+            request.request_text
+        )
+        if not ok:
+            self.get_logger().info(f"Failed to parse function call: {parse_error}")
+            response.response_text = str(parse_error)
+            return response
+        func_obj = getattr(self, function_name, None)
+        if not callable(func_obj):
+            err = f"unknown function: {function_name}"
+            self.get_logger().info(f"Failed to call function: {err}")
+            response.response_text = err
+            return response
         try:
             function_execution_result = func_obj(**function_args)
         except Exception as error:

--- a/llm_robot/test/test_function_call_json.py
+++ b/llm_robot/test/test_function_call_json.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import json
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PKG = os.path.normpath(os.path.join(_HERE, "..", "llm_robot"))
+if _PKG not in sys.path:
+    sys.path.insert(0, _PKG)
+
+from function_call_json import parse_function_call_request  # noqa: E402
+
+
+class TestFunctionCallJson(unittest.TestCase):
+    def test_ok(self):
+        payload = json.dumps(
+            {"name": "publish_cmd_vel", "arguments": '{"linear_x": 0.1}'}
+        )
+        ok, name, args, err = parse_function_call_request(payload)
+        self.assertTrue(ok)
+        self.assertEqual(name, "publish_cmd_vel")
+        self.assertEqual(args, {"linear_x": 0.1})
+        self.assertIsNone(err)
+
+    def test_dict_args(self):
+        payload = json.dumps(
+            {"name": "call_service", "arguments": {"service_name": "/a"}}
+        )
+        ok, name, args, err = parse_function_call_request(payload)
+        self.assertTrue(ok)
+        self.assertEqual(args["service_name"], "/a")
+
+    def test_bad_json(self):
+        ok, name, args, err = parse_function_call_request("{")
+        self.assertFalse(ok)
+        self.assertIn("invalid JSON", err)
+
+    def test_missing_name(self):
+        ok, _, _, err = parse_function_call_request('{"arguments": "{}"}')
+        self.assertFalse(ok)
+        self.assertIn("name", err)
+
+    def test_args_not_object(self):
+        ok, _, _, err = parse_function_call_request(
+            json.dumps({"name": "x", "arguments": "[1,2]"})
+        )
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Robot service callbacks parsed LLM `request_text` / `arguments` with bare `json.loads`. Malformed payloads raised before a response was filled and could fault the ChatGPT function-call service.

## Changes
- Add `parse_function_call_request` (object name + dict args)
- Wire multi_robot, turtlesim, and arx5 callbacks fail-closed
- Reject unknown function names without getattr explode
- Offline unit tests (5)

## Motivation
LLM tool JSON is untrusted; the service boundary should return `response_text` errors instead of raising.

## Verification
```bash
python3 llm_robot/test/test_function_call_json.py -v
```
All 5 tests passed offline.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->