### PR TITLE
fix(model): fail-closed OpenAI choice message shape

### DIFF
--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,6 +46,7 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.openai_response_shape import extract_choice_message
 
 
 # Global Initialization
@@ -202,22 +203,16 @@ class ChatGPTNode(Node):
         The response information includes the message, text, function call, and function flag.
         function_flag = 0: no function call, 1: function call
         """
-        # Getting response information
-        message = chatgpt_response["choices"][0]["message"]
-        content = message.get("content")
-        function_call = message.get("function_call", None)
+        message, content, function_call, function_flag = extract_choice_message(
+            chatgpt_response
+        )
 
-        # Initializing function flag, 0: no function call, 1: function call
-        function_flag = 0
-
-        # If the content is not None, then the response is text
-        # If the content is None, then the response is function call
         if content is not None:
-            function_flag = 0
             self.get_logger().info("OpenAI response type: TEXT")
-        else:
-            function_flag = 1
+        elif function_flag == 1:
             self.get_logger().info("OpenAI response type: FUNCTION CALL")
+        else:
+            self.get_logger().info("OpenAI response type: UNKNOWN_OR_EMPTY")
         # Log
         self.get_logger().info(
             f"Get message from OpenAI: {message}, type: {type(message)}"

--- a/llm_model/llm_model/openai_response_shape.py
+++ b/llm_model/llm_model/openai_response_shape.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Fail-closed extraction of OpenAI ChatCompletion choice message fields."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+
+def extract_choice_message(
+    chatgpt_response: Any,
+) -> Tuple[Dict[str, Any], Optional[Any], Any, int]:
+    """
+    Return (message, content, function_call, function_flag).
+
+    function_flag = 0 for text (or unknown / failure), 1 for function_call.
+    Missing/malformed payloads yield empty message, content None, flag 0.
+    """
+    empty: Dict[str, Any] = {}
+    if not isinstance(chatgpt_response, dict):
+        return empty, None, None, 0
+
+    choices = chatgpt_response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return empty, None, None, 0
+
+    first = choices[0]
+    if not isinstance(first, dict):
+        return empty, None, None, 0
+
+    message = first.get("message")
+    if not isinstance(message, dict):
+        return empty, None, None, 0
+
+    content = message.get("content")
+    function_call = message.get("function_call", None)
+
+    if content is not None:
+        function_flag = 0
+    else:
+        function_flag = 1 if function_call is not None else 0
+
+    return message, content, function_call, function_flag

--- a/llm_model/test/test_openai_response_shape.py
+++ b/llm_model/test/test_openai_response_shape.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2026 Bartok9 (Aerial OSS campaign)
+# Licensed under the Apache License, Version 2.0
+
+import unittest
+
+from llm_model.openai_response_shape import extract_choice_message
+
+
+class TestOpenaiResponseShape(unittest.TestCase):
+    def test_none_response(self):
+        m, c, fc, flag = extract_choice_message(None)
+        self.assertEqual(m, {})
+        self.assertIsNone(c)
+        self.assertIsNone(fc)
+        self.assertEqual(flag, 0)
+
+    def test_empty_choices(self):
+        m, c, fc, flag = extract_choice_message({"choices": []})
+        self.assertEqual(m, {})
+        self.assertEqual(flag, 0)
+
+    def test_missing_message(self):
+        m, c, fc, flag = extract_choice_message({"choices": [{}]})
+        self.assertEqual(m, {})
+        self.assertEqual(flag, 0)
+
+    def test_text_path(self):
+        m, c, fc, flag = extract_choice_message(
+            {"choices": [{"message": {"content": "hello", "role": "assistant"}}]}
+        )
+        self.assertEqual(c, "hello")
+        self.assertIsNone(fc)
+        self.assertEqual(flag, 0)
+        self.assertEqual(m.get("role"), "assistant")
+
+    def test_function_call_path(self):
+        fc_in = {"name": "publish_cmd_vel", "arguments": "{}"}
+        m, c, fc, flag = extract_choice_message(
+            {"choices": [{"message": {"content": None, "function_call": fc_in}}]}
+        )
+        self.assertIsNone(c)
+        self.assertEqual(fc, fc_in)
+        self.assertEqual(flag, 1)
+
+    def test_null_content_without_function_call(self):
+        m, c, fc, flag = extract_choice_message(
+            {"choices": [{"message": {"content": None}}]}
+        )
+        self.assertIsNone(c)
+        self.assertIsNone(fc)
+        self.assertEqual(flag, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Empty OpenAI choices or a missing message used to crash the model node via KeyError/IndexError. Parse fail-closed and treat unknown shapes as non-function-call text path.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->