### PR TITLE
fix(robot): timeout multi_robot ros2 service call

### DIFF
--- a/llm_robot/llm_robot/multi_robot.py
+++ b/llm_robot/llm_robot/multi_robot.py
@@ -33,6 +33,7 @@ from llm_interfaces.srv import ChatGPT
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_robot.service_call_timeout import clamp_timeout, run_ros2_service_call
 
 config = UserConfig()
 
@@ -98,14 +99,9 @@ class MultiRobot(Node):
         # TODO: Add support for non-empty input service
         service_name = kwargs.get("service_name", "")
         service_type = kwargs.get("service_type", "")
+        timeout_sec = clamp_timeout(kwargs.get("timeout", None))
         command = ["ros2", "service", "call", service_name, service_type]
-
-        try:
-            command_result = subprocess.check_output(command, stderr=subprocess.STDOUT)
-            command_result = command_result.decode("utf-8")  # Convert bytes to string
-        except subprocess.CalledProcessError as command_error:
-            command_result = command_error.output.decode("utf-8")
-        return command_result
+        return run_ros2_service_call(command, timeout_sec)
 
     def publish_cmd_vel(self, **kwargs):
         """

--- a/llm_robot/llm_robot/service_call_timeout.py
+++ b/llm_robot/llm_robot/service_call_timeout.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Timeout helpers for multi_robot ros2 service call subprocesses."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import List, Sequence, Union
+
+DEFAULT_TIMEOUT_SEC = 15.0
+MIN_TIMEOUT_SEC = 1.0
+MAX_TIMEOUT_SEC = 60.0
+
+
+def clamp_timeout(value: object, default: float = DEFAULT_TIMEOUT_SEC) -> float:
+    """Clamp optional timeout to [MIN, MAX]; invalid → default."""
+    try:
+        if value is None:
+            return float(default)
+        t = float(value)
+    except (TypeError, ValueError):
+        return float(default)
+    if t != t:  # NaN
+        return float(default)
+    if t < MIN_TIMEOUT_SEC:
+        return MIN_TIMEOUT_SEC
+    if t > MAX_TIMEOUT_SEC:
+        return MAX_TIMEOUT_SEC
+    return t
+
+
+def run_ros2_service_call(
+    command: Sequence[str], timeout_sec: float = DEFAULT_TIMEOUT_SEC
+) -> str:
+    """Run argv list with timeout; never shell=True. Return stdout/stderr text."""
+    try:
+        out = subprocess.check_output(
+            list(command),
+            stderr=subprocess.STDOUT,
+            timeout=float(timeout_sec),
+        )
+        return out.decode("utf-8", errors="replace")
+    except subprocess.TimeoutExpired:
+        return f"error: ros2 service call timed out after {timeout_sec}s"
+    except subprocess.CalledProcessError as command_error:
+        raw = command_error.output or b""
+        return raw.decode("utf-8", errors="replace")
+    except OSError as e:
+        return f"error: failed to run ros2 service call: {e}"

--- a/llm_robot/test/test_service_call_timeout.py
+++ b/llm_robot/test/test_service_call_timeout.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright 2026 Bartok9 (Aerial OSS campaign)
+# Licensed under the Apache License, Version 2.0
+
+import subprocess
+import unittest
+from unittest import mock
+
+from llm_robot.service_call_timeout import (
+    DEFAULT_TIMEOUT_SEC,
+    MAX_TIMEOUT_SEC,
+    MIN_TIMEOUT_SEC,
+    clamp_timeout,
+    run_ros2_service_call,
+)
+
+
+class TestServiceCallTimeout(unittest.TestCase):
+    def test_clamp_default(self):
+        self.assertEqual(clamp_timeout(None), DEFAULT_TIMEOUT_SEC)
+        self.assertEqual(clamp_timeout("bad"), DEFAULT_TIMEOUT_SEC)
+
+    def test_clamp_bounds(self):
+        self.assertEqual(clamp_timeout(0.1), MIN_TIMEOUT_SEC)
+        self.assertEqual(clamp_timeout(999), MAX_TIMEOUT_SEC)
+        self.assertEqual(clamp_timeout(12), 12.0)
+
+    def test_timeout_message(self):
+        with mock.patch(
+            "llm_robot.service_call_timeout.subprocess.check_output",
+            side_effect=subprocess.TimeoutExpired(cmd="x", timeout=15),
+        ):
+            msg = run_ros2_service_call(["ros2", "service", "call", "/a", "pkg/srv/T"], 15)
+        self.assertIn("timed out", msg)
+        self.assertIn("15", msg)
+
+    def test_success_decode(self):
+        with mock.patch(
+            "llm_robot.service_call_timeout.subprocess.check_output",
+            return_value=b"ok-result",
+        ):
+            msg = run_ros2_service_call(["ros2", "service", "call", "/a", "pkg/srv/T"])
+        self.assertEqual(msg, "ok-result")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
multi_robot call_service waited forever on hung ros2 service call. Cap the subprocess (default 15s, clamp 1–60) and return a clear error string.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->