### PR TITLE
fix(input): clamp local Whisper recording duration/rate/gain

### DIFF
--- a/llm_input/llm_input/audio_params_local.py
+++ b/llm_input/llm_input/audio_params_local.py
@@ -1,0 +1,54 @@
+"""Bounded recording parameters for local Whisper ASR path."""
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+
+def _finite_number(value, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a number") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{label} must be finite")
+    return number
+
+
+def clamp_local_recording_params(
+    duration,
+    sample_rate,
+    volume_gain_multiplier,
+    *,
+    min_duration: float = 0.1,
+    max_duration: float = 60.0,
+    min_sample_rate: int = 8000,
+    max_sample_rate: int = 48000,
+    min_gain: float = 0.0,
+    max_gain: float = 10.0,
+) -> Tuple[float, int, float]:
+    """
+    Fail-closed bounds for sounddevice buffer allocation on the local ASR path.
+
+    Returns (duration_s, sample_rate_hz, gain).
+    """
+    duration_f = _finite_number(duration, "duration")
+    if duration_f < min_duration or duration_f > max_duration:
+        raise ValueError(
+            f"duration must be in [{min_duration}, {max_duration}] seconds"
+        )
+
+    rate_f = _finite_number(sample_rate, "sample_rate")
+    rate_i = int(round(rate_f))
+    if rate_i < min_sample_rate or rate_i > max_sample_rate:
+        raise ValueError(
+            f"sample_rate must be in [{min_sample_rate}, {max_sample_rate}] Hz"
+        )
+
+    gain_f = _finite_number(volume_gain_multiplier, "volume_gain_multiplier")
+    if gain_f < min_gain or gain_f > max_gain:
+        raise ValueError(
+            f"volume_gain_multiplier must be in [{min_gain}, {max_gain}]"
+        )
+
+    return duration_f, rate_i, gain_f

--- a/llm_input/llm_input/llm_audio_input_local.py
+++ b/llm_input/llm_input/llm_audio_input_local.py
@@ -40,6 +40,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.audio_params_local import clamp_local_recording_params
 
 config = UserConfig()
 
@@ -75,10 +76,19 @@ class AudioInput(Node):
             self.action_function_listening()
 
     def action_function_listening(self):
-        # Recording settings
-        duration = config.duration  # Audio recording duration, in seconds
-        sample_rate = config.sample_rate  # Sample rate
-        volume_gain_multiplier = config.volume_gain_multiplier  # Volume gain multiplier
+        # Recording settings (bounded before buffer allocation)
+        try:
+            duration, sample_rate, volume_gain_multiplier = (
+                clamp_local_recording_params(
+                    config.duration,
+                    config.sample_rate,
+                    config.volume_gain_multiplier,
+                )
+            )
+        except ValueError as err:
+            self.get_logger().error(f"Invalid local recording params: {err}")
+            self.publish_string("listening", self.llm_state_publisher)
+            return
 
         # Step 1: Record audio
         self.get_logger().info("Start local recording...")

--- a/llm_input/test/test_audio_params_local.py
+++ b/llm_input/test/test_audio_params_local.py
@@ -1,0 +1,25 @@
+import unittest
+
+from llm_input.audio_params_local import clamp_local_recording_params
+
+
+class TestLocalAudioParams(unittest.TestCase):
+    def test_defaults_ok(self):
+        d, r, g = clamp_local_recording_params(5, 16000, 1)
+        self.assertEqual((d, r, g), (5.0, 16000, 1.0))
+
+    def test_rejects_huge_duration(self):
+        with self.assertRaises(ValueError):
+            clamp_local_recording_params(1e9, 16000, 1)
+
+    def test_rejects_nan_gain(self):
+        with self.assertRaises(ValueError):
+            clamp_local_recording_params(5, 16000, float("nan"))
+
+    def test_rejects_bad_rate(self):
+        with self.assertRaises(ValueError):
+            clamp_local_recording_params(5, 100, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bound sounddevice buffer sizing on the local ASR path so huge or non-finite duration/sample_rate/gain cannot OOM the node. Defaults stay valid. Offline unit tests.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->