### PR TITLE
fix(model): bound OpenAI ChatCompletion request timeout

### DIFF
--- a/llm_config/llm_config/user_config.py
+++ b/llm_config/llm_config/user_config.py
@@ -70,6 +70,9 @@ class UserConfig:
         # [optional]: Value that promotes the AI to generates responses with more information at the text prompt
         self.openai_presence_penalty = 0
 
+        # [optional]: OpenAI HTTP request timeout in seconds
+        self.openai_request_timeout = 30
+
         # IO related
         # [optional]: The prompt given to the AI, provided by the user
         self.user_prompt = ""

--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,12 +46,16 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.openai_timeout import clamp_openai_request_timeout
 
 
 # Global Initialization
 config = UserConfig()
 openai.api_key = config.openai_api_key
 # openai.organization = config.openai_organization
+_OPENAI_REQUEST_TIMEOUT = clamp_openai_request_timeout(
+    getattr(config, "openai_request_timeout", 30)
+)
 
 
 class ChatGPTNode(Node):
@@ -183,6 +187,7 @@ class ChatGPTNode(Node):
             messages=messages_input,
             functions=config.robot_functions_list,
             function_call="auto",
+            request_timeout=_OPENAI_REQUEST_TIMEOUT,
             # temperature=config.openai_temperature,
             # top_p=config.openai_top_p,
             # n=config.openai_n,

--- a/llm_model/llm_model/openai_timeout.py
+++ b/llm_model/llm_model/openai_timeout.py
@@ -1,0 +1,27 @@
+"""Clamp OpenAI client request timeout for ROS-LLM model node."""
+from __future__ import annotations
+
+import math
+
+
+def clamp_openai_request_timeout(
+    value,
+    *,
+    default: float = 30.0,
+    minimum: float = 1.0,
+    maximum: float = 120.0,
+) -> float:
+    """Return a finite request timeout in seconds within [minimum, maximum]."""
+    if value is None:
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(number):
+        return default
+    if number < minimum:
+        return minimum
+    if number > maximum:
+        return maximum
+    return number

--- a/llm_model/test/test_openai_timeout.py
+++ b/llm_model/test/test_openai_timeout.py
@@ -1,0 +1,24 @@
+import unittest
+
+from llm_model.openai_timeout import clamp_openai_request_timeout
+
+
+class TestOpenAITimeout(unittest.TestCase):
+    def test_default_none(self):
+        self.assertEqual(clamp_openai_request_timeout(None), 30.0)
+
+    def test_clamp_high(self):
+        self.assertEqual(clamp_openai_request_timeout(9999), 120.0)
+
+    def test_clamp_low(self):
+        self.assertEqual(clamp_openai_request_timeout(0), 1.0)
+
+    def test_nan(self):
+        self.assertEqual(clamp_openai_request_timeout(float("nan")), 30.0)
+
+    def test_ok(self):
+        self.assertEqual(clamp_openai_request_timeout(45), 45.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Clamped request_timeout (default 30s, max 120s) so a hung OpenAI HTTP call cannot block the model node forever. Offline clamp tests.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->