### PR TITLE
fix(input): bound AWS Transcribe job poll wait

### DIFF
--- a/llm_config/llm_config/user_config.py
+++ b/llm_config/llm_config/user_config.py
@@ -110,6 +110,8 @@ class UserConfig:
         self.bucket_name = 'auromixbucket'
         # [optional]: AWS transcription language, change this to 'zh-CN' for Chinese
         self.aws_transcription_language = "en-US"
+        # [optional]: Max seconds to wait for AWS Transcribe job completion
+        self.aws_transcribe_max_wait_sec = 60
         # [optional]: AWS polly voice id, change this to 'Zhiyu' for Chinese
         self.aws_voice_id = "Ivy"
 

--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.transcribe_poll import clamp_transcribe_wait_sec, should_stop_poll  # noqa: E402
 
 config = UserConfig()
 
@@ -135,7 +136,12 @@ class AudioInput(Node):
             Media={"MediaFileUri": transcribe_job_uri},
         )
 
-        # Step 6: Wait until the conversion is complete
+        # Step 6: Wait until the conversion is complete (bounded)
+        max_wait = clamp_transcribe_wait_sec(
+            getattr(config, "aws_transcribe_max_wait_sec", 60)
+        )
+        poll_started = time.time()
+        status = None
         while True:
             status = transcribe.get_transcription_job(
                 TranscriptionJobName=transcribe_job_name
@@ -145,6 +151,13 @@ class AudioInput(Node):
                 "FAILED",
             ]:
                 break
+            elapsed = time.time() - poll_started
+            if should_stop_poll(elapsed, max_wait):
+                self.get_logger().error(
+                    f"Transcribe job timed out after {max_wait}s; re-arming listening"
+                )
+                self.publish_string("listening", self.llm_state_publisher)
+                return
 
             self.get_logger().info("Converting...")
             time.sleep(0.5)

--- a/llm_input/llm_input/transcribe_poll.py
+++ b/llm_input/llm_input/transcribe_poll.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Bounds AWS Transcribe job polling so a stuck job cannot hang the node forever."""
+
+DEFAULT_MAX_WAIT_SEC = 60.0
+ABS_MAX_WAIT_SEC = 300.0
+MIN_WAIT_SEC = 1.0
+
+
+def clamp_transcribe_wait_sec(value, default=DEFAULT_MAX_WAIT_SEC):
+    """Return a finite poll budget in seconds within [MIN_WAIT_SEC, ABS_MAX_WAIT_SEC]."""
+    if value is None:
+        raw = default
+    else:
+        try:
+            raw = float(value)
+        except (TypeError, ValueError):
+            raw = default
+    if raw != raw:  # NaN
+        raw = default
+    if raw < MIN_WAIT_SEC:
+        return MIN_WAIT_SEC
+    if raw > ABS_MAX_WAIT_SEC:
+        return ABS_MAX_WAIT_SEC
+    return raw
+
+
+def should_stop_poll(elapsed_sec, max_wait_sec):
+    """True when polling must stop because the wait budget is exhausted."""
+    try:
+        elapsed = float(elapsed_sec)
+        budget = float(max_wait_sec)
+    except (TypeError, ValueError):
+        return True
+    if elapsed != elapsed or budget != budget:
+        return True
+    return elapsed >= budget

--- a/llm_input/test/test_transcribe_poll.py
+++ b/llm_input/test/test_transcribe_poll.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import unittest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from llm_input.transcribe_poll import (  # noqa: E402
+    ABS_MAX_WAIT_SEC,
+    DEFAULT_MAX_WAIT_SEC,
+    MIN_WAIT_SEC,
+    clamp_transcribe_wait_sec,
+    should_stop_poll,
+)
+
+
+class TestTranscribePoll(unittest.TestCase):
+    def test_default_none(self):
+        self.assertEqual(clamp_transcribe_wait_sec(None), DEFAULT_MAX_WAIT_SEC)
+
+    def test_clamp_high(self):
+        self.assertEqual(clamp_transcribe_wait_sec(9999), ABS_MAX_WAIT_SEC)
+
+    def test_clamp_low(self):
+        self.assertEqual(clamp_transcribe_wait_sec(0), MIN_WAIT_SEC)
+
+    def test_bad_value(self):
+        self.assertEqual(clamp_transcribe_wait_sec("nope"), DEFAULT_MAX_WAIT_SEC)
+        self.assertEqual(clamp_transcribe_wait_sec(float("nan")), DEFAULT_MAX_WAIT_SEC)
+
+    def test_should_stop(self):
+        self.assertFalse(should_stop_poll(10, 60))
+        self.assertTrue(should_stop_poll(60, 60))
+        self.assertTrue(should_stop_poll(61, 60))
+        self.assertTrue(should_stop_poll("x", 60))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bound AWS Transcribe status polling (default 60s, max 300s). On timeout, log and re-arm `listening` instead of hanging forever. Offline clamp tests.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->