### PR TITLE
fix(model): fail-closed on OpenAI ChatCompletion errors

### DIFF
--- a/llm_model/llm_model/chatgpt.py
+++ b/llm_model/llm_model/chatgpt.py
@@ -46,6 +46,10 @@ import os
 import time
 import openai
 from llm_config.user_config import UserConfig
+from llm_model.openai_call_guard import (
+    completion_or_empty,
+    is_usable_chat_completion,
+)
 
 
 # Global Initialization
@@ -178,20 +182,26 @@ class ChatGPTNode(Node):
         """
         # Log
         self.get_logger().info(f"Sending messages to OpenAI: {messages_input}")
-        response = openai.ChatCompletion.create(
-            model=config.openai_model,
-            messages=messages_input,
-            functions=config.robot_functions_list,
-            function_call="auto",
-            # temperature=config.openai_temperature,
-            # top_p=config.openai_top_p,
-            # n=config.openai_n,
-            # stream=config.openai_stream,
-            # stop=config.openai_stop,
-            # max_tokens=config.openai_max_tokens,
-            # presence_penalty=config.openai_presence_penalty,
-            # frequency_penalty=config.openai_frequency_penalty,
-        )
+        try:
+            response = openai.ChatCompletion.create(
+                model=config.openai_model,
+                messages=messages_input,
+                functions=config.robot_functions_list,
+                function_call="auto",
+                # temperature=config.openai_temperature,
+                # top_p=config.openai_top_p,
+                # n=config.openai_n,
+                # stream=config.openai_stream,
+                # stop=config.openai_stop,
+                # max_tokens=config.openai_max_tokens,
+                # presence_penalty=config.openai_presence_penalty,
+                # frequency_penalty=config.openai_frequency_penalty,
+            )
+        except Exception as error:
+            # Fail-closed: never crash the node on network/API errors
+            self.get_logger().error(f"OpenAI ChatCompletion failed: {error}")
+            return completion_or_empty(None, error=error)
+        response = completion_or_empty(response)
         # Log
         self.get_logger().info(f"OpenAI response: {response}")
         return response
@@ -311,10 +321,22 @@ class ChatGPTNode(Node):
         self.add_message_to_history("user", user_prompt)
         # Generate chat completion
         chatgpt_response = self.generate_chatgpt_response(config.chat_history)
-        # Get response information
+        if not is_usable_chat_completion(chatgpt_response):
+            self.get_logger().error(
+                "OpenAI returned unusable completion; skipping assistant update"
+            )
+            self.publish_string("listening", self.llm_state_publisher)
+            return
+        # empty content and no function_call => API failure placeholder
         message, text, function_call, function_flag = self.get_response_information(
             chatgpt_response
         )
+        if text is None and function_call is None:
+            self.get_logger().error(
+                "OpenAI completion empty (no text/function_call); re-arm listening"
+            )
+            self.publish_string("listening", self.llm_state_publisher)
+            return
         # Append response to chat history
         self.add_message_to_history(
             role="assistant", content=text, function_call=function_call

--- a/llm_model/llm_model/openai_call_guard.py
+++ b/llm_model/llm_model/openai_call_guard.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Fail-closed helpers when OpenAI ChatCompletion raises or returns unusable payloads."""
+
+EMPTY_COMPLETION = {
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": None,
+            }
+        }
+    ]
+}
+
+
+def empty_chat_completion():
+    """Return a shallow-safe empty ChatCompletion-like dict (no function_call)."""
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                }
+            }
+        ]
+    }
+
+
+def is_usable_chat_completion(response):
+    """True if response has choices[0].message as a mapping."""
+    if not isinstance(response, dict):
+        return False
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return False
+    first = choices[0]
+    if not isinstance(first, dict):
+        return False
+    message = first.get("message")
+    return isinstance(message, dict)
+
+
+def completion_or_empty(response, error=None):
+    """Prefer usable response; otherwise return empty completion."""
+    if error is not None:
+        return empty_chat_completion()
+    if is_usable_chat_completion(response):
+        return response
+    return empty_chat_completion()

--- a/llm_model/test/test_openai_call_guard.py
+++ b/llm_model/test/test_openai_call_guard.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from llm_model.openai_call_guard import (  # noqa: E402
+    completion_or_empty,
+    empty_chat_completion,
+    is_usable_chat_completion,
+)
+
+
+class TestOpenAICallGuard(unittest.TestCase):
+    def test_empty_shape(self):
+        e = empty_chat_completion()
+        self.assertTrue(is_usable_chat_completion(e))
+        self.assertIsNone(e["choices"][0]["message"]["content"])
+
+    def test_reject_bad(self):
+        self.assertFalse(is_usable_chat_completion(None))
+        self.assertFalse(is_usable_chat_completion({}))
+        self.assertFalse(is_usable_chat_completion({"choices": []}))
+        self.assertFalse(is_usable_chat_completion({"choices": [{"message": "x"}]}))
+
+    def test_accept_good(self):
+        good = {"choices": [{"message": {"role": "assistant", "content": "hi"}}]}
+        self.assertTrue(is_usable_chat_completion(good))
+        self.assertEqual(completion_or_empty(good)["choices"][0]["message"]["content"], "hi")
+
+    def test_error_path(self):
+        out = completion_or_empty({"choices": []}, error=RuntimeError("boom"))
+        self.assertTrue(is_usable_chat_completion(out))
+        self.assertIsNone(out["choices"][0]["message"].get("function_call"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Catch OpenAI ChatCompletion API/network errors, return a safe empty completion, and re-arm listening instead of crashing the model node or mis-routing empty failures as function calls. Offline guard tests.

AI-assisted; human-reviewed.

<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->