### PR TITLE
fix(output): fail-closed Polly synthesize and bound audio read

### DIFF
--- a/llm_output/llm_output/llm_audio_output.py
+++ b/llm_output/llm_output/llm_audio_output.py
@@ -29,10 +29,13 @@ import datetime
 import json
 import requests
 import time
+import subprocess
 
 # AWS ASR related
 import boto3
 import os
+
+from llm_output.polly_call_guard import safe_read_audio_stream
 
 # Audio recording related
 import sounddevice as sd
@@ -81,19 +84,53 @@ class AudioOutput(Node):
     def feedback_for_user_callback(self, msg):
         self.get_logger().info("Received text: '%s'" % msg.data)
 
-        # Call AWS Polly service to synthesize speech
-        polly_client = self.aws_session.client("polly")
-        self.get_logger().info("Polly client successfully initialized.")
-        response = polly_client.synthesize_speech(
-            Text=msg.data, OutputFormat="mp3", VoiceId=config.aws_voice_id
-        )
+        if msg.data is None or not str(msg.data).strip():
+            self.get_logger().warn("Skipping Polly synthesize: empty feedback text")
+            self.publish_string("listening", self.llm_state_publisher)
+            return
+
+        # Call AWS Polly service to synthesize speech (fail-closed)
+        try:
+            polly_client = self.aws_session.client("polly")
+            self.get_logger().info("Polly client successfully initialized.")
+            response = polly_client.synthesize_speech(
+                Text=str(msg.data),
+                OutputFormat="mp3",
+                VoiceId=config.aws_voice_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().error("Polly synthesize_speech failed: %s" % exc)
+            self.publish_string("listening", self.llm_state_publisher)
+            return
+
+        stream = None
+        if isinstance(response, dict):
+            stream = response.get("AudioStream")
+        ok_audio, audio_or_err = safe_read_audio_stream(stream)
+        if not ok_audio:
+            self.get_logger().error("Polly audio read failed: %s" % audio_or_err)
+            self.publish_string("listening", self.llm_state_publisher)
+            return
 
         # Save the audio output to a file
         output_file_path = "/tmp/speech_output.mp3"
-        with open(output_file_path, "wb") as file:
-            file.write(response["AudioStream"].read())
-        # Play the audio output
-        os.system("mpv" + " " + output_file_path)
+        try:
+            with open(output_file_path, "wb") as file:
+                file.write(audio_or_err)
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().error("Failed to write speech file: %s" % exc)
+            self.publish_string("listening", self.llm_state_publisher)
+            return
+
+        # Play without shell concat (avoid injection on path changes)
+        try:
+            subprocess.run(
+                ["mpv", "--", output_file_path],
+                check=False,
+                timeout=120,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().error("mpv playback failed: %s" % exc)
         self.get_logger().info("Finished Polly playing.")
         self.publish_string("feedback finished", self.llm_state_publisher)
         self.publish_string("listening", self.llm_state_publisher)

--- a/llm_output/llm_output/polly_call_guard.py
+++ b/llm_output/llm_output/polly_call_guard.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Daniel Pike / Bartok9 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fail-closed helpers for AWS Polly synthesize_speech audio streams."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple, Union
+
+_DEFAULT_MAX = 5_000_000
+_MIN_MAX = 1_000
+_MAX_MAX = 20_000_000
+
+
+def clamp_polly_audio_max_bytes(value: Any, default: int = _DEFAULT_MAX) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        n = int(default)
+    if n < _MIN_MAX:
+        return _MIN_MAX
+    if n > _MAX_MAX:
+        return _MAX_MAX
+    return n
+
+
+def safe_read_audio_stream(
+    stream: Any, max_bytes: Any = _DEFAULT_MAX
+) -> Tuple[bool, Union[bytes, str]]:
+    """Read Polly AudioStream with a hard byte cap.
+
+    Returns (True, bytes) on success, (False, error_message) otherwise.
+    """
+    limit = clamp_polly_audio_max_bytes(max_bytes)
+    if stream is None:
+        return False, "missing AudioStream"
+    read = getattr(stream, "read", None)
+    if not callable(read):
+        return False, "AudioStream has no read()"
+    try:
+        # read one extra byte to detect overflow without loading unbounded
+        data = read(limit + 1)
+    except Exception as exc:  # noqa: BLE001 — fail-closed network/SDK errors
+        return False, "AudioStream read failed: %s" % exc
+    if data is None:
+        return False, "AudioStream returned None"
+    if not isinstance(data, (bytes, bytearray)):
+        try:
+            data = bytes(data)
+        except Exception:
+            return False, "AudioStream did not return bytes"
+    data = bytes(data)
+    if len(data) > limit:
+        return False, "AudioStream exceeds max_bytes=%s" % limit
+    if len(data) == 0:
+        return False, "AudioStream empty"
+    return True, data

--- a/llm_output/test/test_polly_call_guard.py
+++ b/llm_output/test/test_polly_call_guard.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import unittest
+
+from llm_output.polly_call_guard import (
+    clamp_polly_audio_max_bytes,
+    safe_read_audio_stream,
+)
+
+
+class _Stream:
+    def __init__(self, payload, raise_on_read=False):
+        self._payload = payload
+        self._raise = raise_on_read
+
+    def read(self, n=-1):
+        if self._raise:
+            raise OSError("boom")
+        if n is None or n < 0:
+            return self._payload
+        return self._payload[:n]
+
+
+class TestPollyCallGuard(unittest.TestCase):
+    def test_clamp(self):
+        self.assertEqual(clamp_polly_audio_max_bytes(100), 1000)
+        self.assertEqual(clamp_polly_audio_max_bytes(10**12), 20_000_000)
+        self.assertEqual(clamp_polly_audio_max_bytes("bad"), 5_000_000)
+
+    def test_read_ok(self):
+        ok, data = safe_read_audio_stream(_Stream(b"abc"), max_bytes=1000)
+        self.assertTrue(ok)
+        self.assertEqual(data, b"abc")
+
+    def test_read_overflow(self):
+        ok, err = safe_read_audio_stream(_Stream(b"0123456789"), max_bytes=1000)
+        # 10 bytes < 1000 min clamp -> ok
+        self.assertTrue(ok)
+        ok, err = safe_read_audio_stream(_Stream(b"x" * 2000), max_bytes=1000)
+        self.assertFalse(ok)
+        self.assertIn("max_bytes", err)
+
+    def test_read_error(self):
+        ok, err = safe_read_audio_stream(_Stream(b"x", raise_on_read=True))
+        self.assertFalse(ok)
+        self.assertIn("failed", err)
+
+    def test_missing(self):
+        ok, err = safe_read_audio_stream(None)
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Polly `synthesize_speech` and unbounded `AudioStream.read()` could crash or hang the TTS node. Catch API errors, cap stream bytes, and play mp3 with subprocess argv (no shell).

Offline unit tests for the byte-cap helper.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->