### PR TITLE
fix(input): bound AWS Transcribe transcript HTTP fetch

### DIFF
--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,11 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.transcript_http import (
+    clamp_transcript_http_max_bytes,
+    clamp_transcript_http_timeout,
+    parse_transcript_http_body,
+)
 
 config = UserConfig()
 
@@ -149,14 +154,39 @@ class AudioInput(Node):
             self.get_logger().info("Converting...")
             time.sleep(0.5)
 
-        # Step 7: Get the transcribed text
+        # Step 7: Get the transcribed text (bounded HTTP)
         if status["TranscriptionJob"]["TranscriptionJobStatus"] == "COMPLETED":
             transcript_file_url = status["TranscriptionJob"]["Transcript"][
                 "TranscriptFileUri"
             ]
-            response = requests.get(transcript_file_url)
-            transcript_data = json.loads(response.text)
-            transcript_text = transcript_data["results"]["transcripts"][0]["transcript"]
+            http_timeout = clamp_transcript_http_timeout(
+                getattr(config, "aws_transcript_http_timeout_sec", 15)
+            )
+            max_bytes = clamp_transcript_http_max_bytes(
+                getattr(config, "aws_transcript_http_max_bytes", 1_000_000)
+            )
+            try:
+                response = requests.get(transcript_file_url, timeout=http_timeout)
+                response.raise_for_status()
+                content = response.content
+            except Exception as exc:  # noqa: BLE001
+                self.get_logger().error(
+                    "Failed to fetch transcript JSON: %s" % exc
+                )
+                self.publish_string("listening", self.llm_state_publisher)
+                return
+
+            ok_body, transcript_or_err = parse_transcript_http_body(
+                content, max_bytes=max_bytes
+            )
+            if not ok_body:
+                self.get_logger().error(
+                    "Invalid transcript payload: %s" % transcript_or_err
+                )
+                self.publish_string("listening", self.llm_state_publisher)
+                return
+
+            transcript_text = transcript_or_err
             self.get_logger().info("Audio to text conversion complete!")
             # Step 8: Publish the transcribed text to ROS2
             if transcript_text == "":  # Empty input
@@ -165,12 +195,16 @@ class AudioInput(Node):
             else:
                 self.publish_string(transcript_text, self.audio_to_text_publisher)
             # Step 9: Delete the temporary audio file from AWS S3
-            s3.delete_object(Bucket=bucket_name, Key=audio_file_key)
+            try:
+                s3.delete_object(Bucket=bucket_name, Key=audio_file_key)
+            except Exception as exc:  # noqa: BLE001
+                self.get_logger().warn("S3 cleanup failed: %s" % exc)
 
         else:
             self.get_logger().error(
                 f"Failed to transcribe audio: {status['TranscriptionJob']['FailureReason']}"
             )
+            self.publish_string("listening", self.llm_state_publisher)
 
     def publish_string(self, string_to_send, publisher_to_use):
         msg = String()

--- a/llm_input/llm_input/transcript_http.py
+++ b/llm_input/llm_input/transcript_http.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# flake8: noqa
+#
+# Copyright 2023 Herman Ye @Auromix
+# Copyright 2026 Daniel Pike / Bartok9 contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bounded HTTP fetch helpers for AWS Transcribe transcript JSON."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Tuple, Union
+
+_DEFAULT_TIMEOUT = 15.0
+_MIN_TIMEOUT = 1.0
+_MAX_TIMEOUT = 120.0
+
+_DEFAULT_MAX_BYTES = 1_000_000
+_MIN_MAX_BYTES = 1024
+_MAX_MAX_BYTES = 10_000_000
+
+
+def clamp_transcript_http_timeout(value: Any, default: float = _DEFAULT_TIMEOUT) -> float:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        n = float(default)
+    if n < _MIN_TIMEOUT:
+        return _MIN_TIMEOUT
+    if n > _MAX_TIMEOUT:
+        return _MAX_TIMEOUT
+    return n
+
+
+def clamp_transcript_http_max_bytes(value: Any, default: int = _DEFAULT_MAX_BYTES) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        n = int(default)
+    if n < _MIN_MAX_BYTES:
+        return _MIN_MAX_BYTES
+    if n > _MAX_MAX_BYTES:
+        return _MAX_MAX_BYTES
+    return n
+
+
+def extract_transcript_text(payload: Any) -> Tuple[bool, str]:
+    """Fail-closed navigate Transcribe transcript JSON."""
+    if not isinstance(payload, dict):
+        return False, "transcript payload is not an object"
+    results = payload.get("results")
+    if not isinstance(results, dict):
+        return False, "missing results object"
+    transcripts = results.get("transcripts")
+    if not isinstance(transcripts, list) or not transcripts:
+        return False, "missing transcripts list"
+    first = transcripts[0]
+    if not isinstance(first, dict):
+        return False, "transcript entry is not an object"
+    text = first.get("transcript")
+    if text is None:
+        return False, "missing transcript field"
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return False, "transcript not coercible to str"
+    return True, text
+
+
+def parse_transcript_http_body(
+    body: Union[bytes, bytearray, str], max_bytes: Any = _DEFAULT_MAX_BYTES
+) -> Tuple[bool, str]:
+    """Decode + JSON-parse bounded body; return (ok, transcript_or_err)."""
+    limit = clamp_transcript_http_max_bytes(max_bytes)
+    if body is None:
+        return False, "empty body"
+    if isinstance(body, str):
+        raw = body.encode("utf-8", errors="replace")
+    else:
+        raw = bytes(body)
+    if len(raw) > limit:
+        return False, "transcript body exceeds max_bytes=%s" % limit
+    try:
+        text = raw.decode("utf-8")
+    except Exception as exc:  # noqa: BLE001
+        return False, "utf-8 decode failed: %s" % exc
+    try:
+        payload = json.loads(text)
+    except Exception as exc:  # noqa: BLE001
+        return False, "json parse failed: %s" % exc
+    return extract_transcript_text(payload)

--- a/llm_input/test/test_transcript_http.py
+++ b/llm_input/test/test_transcript_http.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import json
+import unittest
+
+from llm_input.transcript_http import (
+    clamp_transcript_http_max_bytes,
+    clamp_transcript_http_timeout,
+    extract_transcript_text,
+    parse_transcript_http_body,
+)
+
+
+class TestTranscriptHttp(unittest.TestCase):
+    def test_clamp_timeout(self):
+        self.assertEqual(clamp_transcript_http_timeout(0), 1.0)
+        self.assertEqual(clamp_transcript_http_timeout(9999), 120.0)
+        self.assertEqual(clamp_transcript_http_timeout("x"), 15.0)
+
+    def test_clamp_bytes(self):
+        self.assertEqual(clamp_transcript_http_max_bytes(10), 1024)
+        self.assertEqual(clamp_transcript_http_max_bytes(10**12), 10_000_000)
+
+    def test_extract(self):
+        ok, t = extract_transcript_text(
+            {"results": {"transcripts": [{"transcript": "hello"}]}}
+        )
+        self.assertTrue(ok)
+        self.assertEqual(t, "hello")
+        ok, err = extract_transcript_text({})
+        self.assertFalse(ok)
+
+    def test_parse_body(self):
+        body = json.dumps(
+            {"results": {"transcripts": [{"transcript": "hi robot"}]}}
+        ).encode()
+        ok, t = parse_transcript_http_body(body)
+        self.assertTrue(ok)
+        self.assertEqual(t, "hi robot")
+        ok, err = parse_transcript_http_body(b"x" * 2000, max_bytes=1024)
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Transcribe result `requests.get` had no timeout and loaded unbounded JSON. Cap wait/body size, fail-closed path parse, re-arm listening on errors.

Offline unit tests for clamps and JSON extract.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->