### PR TITLE
fix(input): best-effort AWS Transcribe job cleanup

### DIFF
--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,10 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.transcribe_job_cleanup import (
+    sanitize_transcribe_job_name,
+    should_attempt_job_delete,
+)
 
 config = UserConfig()
 
@@ -171,6 +175,19 @@ class AudioInput(Node):
             self.get_logger().error(
                 f"Failed to transcribe audio: {status['TranscriptionJob']['FailureReason']}"
             )
+
+        # Best-effort Transcribe job cleanup (avoid account job buildup)
+        job_status = status["TranscriptionJob"]["TranscriptionJobStatus"]
+        safe_name = sanitize_transcribe_job_name(transcribe_job_name)
+        if safe_name and should_attempt_job_delete(job_status):
+            try:
+                transcribe.delete_transcription_job(
+                    TranscriptionJobName=safe_name
+                )
+            except Exception as exc:  # noqa: BLE001
+                self.get_logger().warn(
+                    "Transcribe job cleanup failed: %s" % exc
+                )
 
     def publish_string(self, string_to_send, publisher_to_use):
         msg = String()

--- a/llm_input/llm_input/transcribe_job_cleanup.py
+++ b/llm_input/llm_input/transcribe_job_cleanup.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Helpers for best-effort AWS Transcribe job cleanup."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+_JOB_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,200}$")
+_DELETE_STATUSES = frozenset({"COMPLETED", "FAILED"})
+
+
+def sanitize_transcribe_job_name(name: Optional[str]) -> Optional[str]:
+    """Return job name if safe for delete_transcription_job; else None."""
+    if name is None:
+        return None
+    if not isinstance(name, str):
+        return None
+    stripped = name.strip()
+    if not stripped or not _JOB_NAME_RE.match(stripped):
+        return None
+    if ".." in stripped or "/" in stripped or "\\" in stripped:
+        return None
+    return stripped
+
+
+def should_attempt_job_delete(status: Optional[str]) -> bool:
+    """True when the Transcribe job is in a terminal state worth deleting."""
+    if not isinstance(status, str):
+        return False
+    return status.strip().upper() in _DELETE_STATUSES

--- a/llm_input/test/test_transcribe_job_cleanup.py
+++ b/llm_input/test/test_transcribe_job_cleanup.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "llm_input"))
+
+from transcribe_job_cleanup import (  # noqa: E402
+    sanitize_transcribe_job_name,
+    should_attempt_job_delete,
+)
+
+
+class TestTranscribeJobCleanup(unittest.TestCase):
+    def test_sanitize_ok(self):
+        name = "my-transcribe-job-2026-07-29-04-10-00"
+        self.assertEqual(sanitize_transcribe_job_name(name), name)
+
+    def test_sanitize_reject(self):
+        self.assertIsNone(sanitize_transcribe_job_name(""))
+        self.assertIsNone(sanitize_transcribe_job_name(None))
+        self.assertIsNone(sanitize_transcribe_job_name("../evil"))
+        self.assertIsNone(sanitize_transcribe_job_name("a/b"))
+        self.assertIsNone(sanitize_transcribe_job_name("has space"))
+        self.assertIsNone(sanitize_transcribe_job_name("x" * 201))
+
+    def test_should_delete(self):
+        self.assertTrue(should_attempt_job_delete("COMPLETED"))
+        self.assertTrue(should_attempt_job_delete("FAILED"))
+        self.assertTrue(should_attempt_job_delete(" completed "))
+        self.assertFalse(should_attempt_job_delete("IN_PROGRESS"))
+        self.assertFalse(should_attempt_job_delete(None))
+        self.assertFalse(should_attempt_job_delete(""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AWS Transcribe jobs were never deleted after COMPLETED/FAILED, so demos leave account clutter. Sanitize job name and best-effort delete_transcription_job; offline unit tests for the helpers.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
