### PR TITLE
fix(input): resolve tmp audio under /tmp and unlink after use

### DIFF
--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -45,6 +45,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.tmp_audio_path import resolve_tmp_audio_path, safe_unlink
 
 config = UserConfig()
 
@@ -54,7 +55,7 @@ class AudioInput(Node):
         super().__init__("llm_audio_input")
 
         # AWS service initialization
-        self.aws_audio_file = "/tmp/user_audio_input.flac"
+        self.aws_audio_file = resolve_tmp_audio_path("/tmp/user_audio_input.flac")
         self.aws_access_key_id = config.aws_access_key_id
         self.aws_secret_access_key = config.aws_secret_access_key
         self.aws_region_name = config.aws_region_name
@@ -164,7 +165,8 @@ class AudioInput(Node):
                 self.publish_string("listening", self.llm_state_publisher)
             else:
                 self.publish_string(transcript_text, self.audio_to_text_publisher)
-            # Step 9: Delete the temporary audio file from AWS S3
+            safe_unlink(self.aws_audio_file)
+            # Step 9 Delete the temporary audio file from AWS S3
             s3.delete_object(Bucket=bucket_name, Key=audio_file_key)
 
         else:

--- a/llm_input/llm_input/llm_audio_input_local.py
+++ b/llm_input/llm_input/llm_audio_input_local.py
@@ -40,6 +40,7 @@ from std_msgs.msg import String
 
 # Global Initialization
 from llm_config.user_config import UserConfig
+from llm_input.tmp_audio_path import resolve_tmp_audio_path, safe_unlink
 
 config = UserConfig()
 
@@ -48,7 +49,7 @@ class AudioInput(Node):
     def __init__(self):
         super().__init__("llm_audio_input")
         # tmp audio file
-        self.tmp_audio_file = "/tmp/user_audio_input.flac"
+        self.tmp_audio_file = resolve_tmp_audio_path("/tmp/user_audio_input.flac")
 
         # Initialization publisher
         self.initialization_publisher = self.create_publisher(
@@ -113,8 +114,10 @@ class AudioInput(Node):
         if transcript_text == "":  # Empty input
             self.get_logger().info("Empty input!")
             self.publish_string("listening", self.llm_state_publisher)
+            safe_unlink(self.tmp_audio_file)
         else:
             self.publish_string(transcript_text, self.audio_to_text_publisher)
+            safe_unlink(self.tmp_audio_file)
 
     def publish_string(self, string_to_send, publisher_to_use):
         msg = String()

--- a/llm_input/llm_input/tmp_audio_path.py
+++ b/llm_input/llm_input/tmp_audio_path.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Resolve and unlink demo temp audio paths under /tmp only."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+DEFAULT_TMP_AUDIO = "/tmp/user_audio_input.flac"
+_ALLOWED_SUFFIXES = (".flac", ".wav")
+_MAX_PATH_LEN = 180
+
+
+def resolve_tmp_audio_path(path: Optional[str] = None) -> str:
+    """
+    Return a sanitized absolute path under /tmp for temp audio.
+
+    Falls back to DEFAULT_TMP_AUDIO when input is missing or unsafe.
+    """
+    candidate = DEFAULT_TMP_AUDIO if path is None else str(path).strip()
+    if not candidate:
+        candidate = DEFAULT_TMP_AUDIO
+    if len(candidate) > _MAX_PATH_LEN:
+        return os.path.realpath(DEFAULT_TMP_AUDIO)
+    # No null bytes or obvious path tricks before resolve
+    if "\x00" in candidate or ".." in candidate.split(os.sep):
+        return os.path.realpath(DEFAULT_TMP_AUDIO)
+    expanded = os.path.expanduser(candidate)
+    # Prefer absolute; if relative, join under /tmp basename only
+    if not os.path.isabs(expanded):
+        expanded = os.path.join("/tmp", os.path.basename(expanded))
+    real = os.path.realpath(expanded)
+    tmp_root = os.path.realpath("/tmp")
+    if real != tmp_root and not real.startswith(tmp_root + os.sep):
+        return os.path.realpath(DEFAULT_TMP_AUDIO)
+    lower = real.lower()
+    if not lower.endswith(_ALLOWED_SUFFIXES):
+        return os.path.realpath(DEFAULT_TMP_AUDIO)
+    base = os.path.basename(real)
+    if not base or base in (".", ".."):
+        return os.path.realpath(DEFAULT_TMP_AUDIO)
+    return real
+
+
+def safe_unlink(path: Optional[str]) -> bool:
+    """Unlink path only if it resolves as an allowed tmp audio path."""
+    if path is None:
+        return False
+    try:
+        resolved = resolve_tmp_audio_path(path)
+    except Exception:
+        return False
+    # Only unlink if caller path canonicalizes to the same allowed target
+    try:
+        caller_real = os.path.realpath(os.path.expanduser(str(path)))
+    except Exception:
+        return False
+    if caller_real != resolved:
+        # Still allow unlink of default if resolve remapped unsafe → default
+        # but never unlink a path that is not under /tmp with audio suffix
+        tmp_root = os.path.realpath("/tmp")
+        if not (
+            caller_real.startswith(tmp_root + os.sep)
+            and caller_real.lower().endswith(_ALLOWED_SUFFIXES)
+        ):
+            return False
+        target = caller_real
+    else:
+        target = resolved
+    try:
+        os.unlink(target)
+        return True
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False

--- a/llm_input/test/test_tmp_audio_path.py
+++ b/llm_input/test/test_tmp_audio_path.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "llm_input"))
+
+from tmp_audio_path import DEFAULT_TMP_AUDIO, resolve_tmp_audio_path, safe_unlink  # noqa: E402
+
+
+class TestTmpAudioPath(unittest.TestCase):
+    def test_default(self):
+        self.assertEqual(resolve_tmp_audio_path(None), os.path.realpath(DEFAULT_TMP_AUDIO))
+        self.assertEqual(resolve_tmp_audio_path(""), os.path.realpath(DEFAULT_TMP_AUDIO))
+
+    def test_reject_outside_tmp(self):
+        self.assertEqual(
+            resolve_tmp_audio_path("/etc/passwd.flac"),
+            os.path.realpath(DEFAULT_TMP_AUDIO),
+        )
+        self.assertEqual(
+            resolve_tmp_audio_path("/var/tmp/x.flac"),
+            os.path.realpath(DEFAULT_TMP_AUDIO),
+        )
+
+    def test_reject_bad_suffix(self):
+        self.assertEqual(
+            resolve_tmp_audio_path("/tmp/evil.sh"),
+            os.path.realpath(DEFAULT_TMP_AUDIO),
+        )
+
+    def test_ok_under_tmp(self):
+        p = "/tmp/user_audio_input.wav"
+        self.assertEqual(resolve_tmp_audio_path(p), os.path.realpath(p))
+
+    def test_safe_unlink_missing_ok(self):
+        self.assertTrue(safe_unlink("/tmp/definitely-missing-ros-llm-test.flac"))
+
+    def test_safe_unlink_creates_and_removes(self):
+        path = "/tmp/ros_llm_test_unlink.flac"
+        with open(path, "wb") as f:
+            f.write(b"x")
+        self.assertTrue(safe_unlink(path))
+        self.assertFalse(os.path.exists(path))
+
+    def test_safe_unlink_rejects_outside(self):
+        # should not throw; should not unlink /etc if somehow passed
+        self.assertFalse(safe_unlink("/etc/hosts"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Temp speech files used fixed /tmp paths and were never unlinked. Resolve under /tmp only and safe_unlink after transcript publish (AWS + local Whisper). Offline unit tests.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->
