### PR TITLE
fix(input): republish listening after Transcribe FAILED

### DIFF
--- a/llm_input/llm_input/llm_audio_input.py
+++ b/llm_input/llm_input/llm_audio_input.py
@@ -169,8 +169,10 @@ class AudioInput(Node):
 
         else:
             self.get_logger().error(
-                f"Failed to transcribe audio: {status['TranscriptionJob']['FailureReason']}"
+                f"Failed to transcribe audio: {status['TranscriptionJob'].get('FailureReason', 'unknown')}"
             )
+            # Return to listening so one failed job does not stall the pipeline
+            self.publish_string("listening", self.llm_state_publisher)
 
     def publish_string(self, string_to_send, publisher_to_use):
         msg = String()


### PR DESCRIPTION
Failed AWS Transcribe jobs only logged an error and never republished `listening`, so the audio input node could stall after one failure. Mirror the empty-transcript path and return to listening.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->