### PR TITLE
fix(robot): wait for turtlesim /reset service result

### DIFF
--- a/llm_robot/llm_robot/turtle_robot.py
+++ b/llm_robot/llm_robot/turtle_robot.py
@@ -104,8 +104,18 @@ class TurtleRobot(Node):
         Resets the turtlesim to its initial state and clears the screen
         """
         empty_req = Empty.Request()
+        timeout_sec = 5.0
         try:
             future = self.reset_client.call_async(empty_req)
+            rclpy.spin_until_future_complete(self, future, timeout_sec=timeout_sec)
+            if not future.done():
+                msg = f"Timed out waiting for /reset after {timeout_sec}s"
+                self.get_logger().error(msg)
+                return msg
+            exc = future.exception()
+            if exc is not None:
+                self.get_logger().error(f"Failed to reset turtlesim: {exc}")
+                return str(exc)
             response_text = "Reset turtlesim successfully"
         except Exception as error:
             self.get_logger().info(f"Failed to reset turtlesim: {error}")


### PR DESCRIPTION
TurtleSim `reset_turtlesim` called `call_async` on `/reset` but never waited, so the function_call path always reported success. Wait up to 5s for the future and return timeout/exception text to the caller.

AI-assisted; human-reviewed.


<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->